### PR TITLE
Add a default owner for the repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in
+# the repo. 
+*       @andyjeffries


### PR DESCRIPTION
We do this at https://github.com/okteto/okteto and find it useful so that contributors don't have to manually add a reviewer to the PR.