### PR TITLE
add rename endpoint for firewall

### DIFF
--- a/client.go
+++ b/client.go
@@ -167,8 +167,8 @@ func (c *Client) sendRequest(req *http.Request) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	
-  	body, err := ioutil.ReadAll(resp.Body)
+
+	body, err := ioutil.ReadAll(resp.Body)
 	c.LastJSONResponse = string(body)
 
 	if resp.StatusCode >= 300 {

--- a/client.go
+++ b/client.go
@@ -168,7 +168,7 @@ func (c *Client) sendRequest(req *http.Request) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 	
-  body, err := ioutil.ReadAll(resp.Body)
+  	body, err := ioutil.ReadAll(resp.Body)
 	c.LastJSONResponse = string(body)
 
 	if resp.StatusCode >= 300 {

--- a/client.go
+++ b/client.go
@@ -190,10 +190,9 @@ func (c *Client) SendPostRequest(requestURL string, params interface{}) ([]byte,
 	u := c.prepareClientURL(requestURL)
 
 	// we create a new buffer and encode everything to json to send it in the request
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(params)
+	jsonValue, _ := json.Marshal(params)
 
-	req, err := http.NewRequest("POST", u.String(), buf)
+	req, err := http.NewRequest("POST", u.String(), bytes.NewBuffer(jsonValue))
 	if err != nil {
 		return nil, err
 	}
@@ -205,10 +204,9 @@ func (c *Client) SendPutRequest(requestURL string, params interface{}) ([]byte, 
 	u := c.prepareClientURL(requestURL)
 
 	// we create a new buffer and encode everything to json to send it in the request
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(params)
+	jsonValue, _ := json.Marshal(params)
 
-	req, err := http.NewRequest("PUT", u.String(), buf)
+	req, err := http.NewRequest("PUT", u.String(), bytes.NewBuffer(jsonValue))
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -29,6 +29,7 @@ type Client struct {
 type HTTPError struct {
 	Code   int
 	Status string
+	Reason string
 }
 
 // Result is the result of a SimpleResponse
@@ -46,7 +47,7 @@ type SimpleResponse struct {
 const ResultSuccess = "success"
 
 func (e HTTPError) Error() string {
-	return fmt.Sprintf("%d: %s", e.Code, e.Status)
+	return fmt.Sprintf("%d: %s, %s", e.Code, e.Status, e.Reason)
 }
 
 // NewClientWithURL initializes a Client with a specific API URL
@@ -166,12 +167,14 @@ func (c *Client) sendRequest(req *http.Request) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode >= 300 {
-		return nil, HTTPError{Code: resp.StatusCode, Status: resp.Status}
-	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	c.LastJSONResponse = string(body)
+
+	if resp.StatusCode >= 300 {
+		return nil, HTTPError{Code: resp.StatusCode, Status: resp.Status, Reason: string(body)}
+	}
+
 	return body, err
 }
 

--- a/client.go
+++ b/client.go
@@ -10,8 +10,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
-
-	"github.com/ajg/form"
 )
 
 // Version represents the version of the CLI
@@ -206,17 +204,12 @@ func (c *Client) SendPostRequest(requestURL string, params interface{}) ([]byte,
 // SendPutRequest sends a correctly authenticated put request to the API server
 func (c *Client) SendPutRequest(requestURL string, params interface{}) ([]byte, error) {
 	u := c.prepareClientURL(requestURL)
-	values, err := form.EncodeToValues(params)
-	if err != nil {
-		return nil, err
-	}
 
-	body := values.Encode()
-	if body == "=" {
-		body = ""
-	}
+	// we create a new buffer and encode everything to json to send it in the request
+	buf := new(bytes.Buffer)
+	json.NewEncoder(buf).Encode(params)
 
-	req, err := http.NewRequest("PUT", u.String(), strings.NewReader(body))
+	req, err := http.NewRequest("PUT", u.String(), buf)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -70,7 +70,7 @@ func NewClientWithURL(apiKey string, civoAPIURL string) (*Client, error) {
 
 // NewClient initializes a Client connecting to the production API
 func NewClient(apiKey string) (*Client, error) {
-	return NewClientWithURL(apiKey, "https://api-staging.civo.com")
+	return NewClientWithURL(apiKey, "https://api.civo.com")
 }
 
 // NewAdvancedClientForTesting initializes a Client connecting to a local test server and allows for specifying methods

--- a/client.go
+++ b/client.go
@@ -90,8 +90,7 @@ func NewAdvancedClientForTesting(responses map[string]map[string]string) (*Clien
 			if strings.Contains(req.URL.String(), url) &&
 				req.Method == criteria["method"] {
 				if criteria["method"] == "PUT" || criteria["method"] == "POST" || criteria["method"] == "PATCH" {
-
-					if string(body) == criteria["requestBody"] {
+					if strings.TrimSpace(string(body)) == strings.TrimSpace(criteria["requestBody"]) {
 						responseSent = true
 						rw.Write([]byte(criteria["responseBody"]))
 					}

--- a/dns.go
+++ b/dns.go
@@ -21,7 +21,7 @@ type DNSDomain struct {
 }
 
 type dnsDomainConfig struct {
-	Name string `form:"name"`
+	Name string `json:"name"`
 }
 
 // DNSRecordType represents the allowed record types: a, cname, mx or txt
@@ -45,11 +45,11 @@ type DNSRecord struct {
 // none of the fields are mandatory and will be automatically
 // set with default values
 type DNSRecordConfig struct {
-	Type     DNSRecordType `form:"type"`
-	Name     string        `form:"name"`
-	Value    string        `form:"value"`
-	Priority int           `form:"priority"`
-	TTL      int           `form:"ttl"`
+	Type     DNSRecordType `json:"type"`
+	Name     string        `json:"name"`
+	Value    string        `json:"value"`
+	Priority int           `json:"priority"`
+	TTL      int           `json:"ttl"`
 }
 
 const (

--- a/firewall.go
+++ b/firewall.go
@@ -107,6 +107,18 @@ func (c *Client) NewFirewall(name string) (*FirewallResult, error) {
 	return result, nil
 }
 
+// RenameFirewall rename firewall
+func (c *Client) RenameFirewall(id string, name string) (*SimpleResponse, error) {
+	resp, err := c.SendPutRequest(fmt.Sprintf("/v2/firewalls/%s", id), map[string]string{
+		"name": name,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return c.DecodeSimpleResponse(resp)
+}
+
 // DeleteFirewall deletes an firewall
 func (c *Client) DeleteFirewall(id string) (*SimpleResponse, error) {
 	resp, err := c.SendDeleteRequest("/v2/firewalls/" + id)

--- a/firewall.go
+++ b/firewall.go
@@ -38,17 +38,17 @@ type FirewallRule struct {
 
 // FirewallRuleConfig is how you specify the details when creating a new rule
 type FirewallRuleConfig struct {
-	FirewallID string   `form:"firewall_id"`
-	Protocol   string   `form:"protocol"`
-	StartPort  string   `form:"start_port"`
-	EndPort    string   `form:"end_port"`
-	Cidr       []string `form:"cidr"`
-	Direction  string   `form:"direction"`
-	Label      string   `form:"label,omitempty"`
+	FirewallID string   `json:"firewall_id"`
+	Protocol   string   `json:"protocol"`
+	StartPort  string   `json:"start_port"`
+	EndPort    string   `json:"end_port"`
+	Cidr       []string `json:"cidr"`
+	Direction  string   `json:"direction"`
+	Label      string   `json:"label,omitempty"`
 }
 
 type firewallConfig struct {
-	Name string `form:"name"`
+	Name string `json:"name"`
 }
 
 // ListFirewalls returns all firewall owned by the calling API account

--- a/firewall_test.go
+++ b/firewall_test.go
@@ -94,6 +94,23 @@ func TestNewFirewall(t *testing.T) {
 	}
 }
 
+func TestRenameFirewall(t *testing.T) {
+	client, server, _ := NewClientForTesting(map[string]string{
+		"/v2/firewalls/12346": `{"result": "success"}`,
+	})
+	defer server.Close()
+	got, err := client.RenameFirewall("12346", "new_name")
+	if err != nil {
+		t.Errorf("Request returned an error: %s", err)
+		return
+	}
+
+	expected := &SimpleResponse{Result: "success"}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("Expected %+v, got %+v", expected, got)
+	}
+}
+
 func TestDeleteFirewall(t *testing.T) {
 	client, server, _ := NewClientForTesting(map[string]string{
 		"/v2/firewalls/12346": `{"result": "success"}`,

--- a/instance.go
+++ b/instance.go
@@ -59,20 +59,20 @@ type PaginatedInstanceList struct {
 // none of the fields are mandatory and will be automatically
 // set with default values
 type InstanceConfig struct {
-	Count            int      `form:"count"`
-	Hostname         string   `form:"hostname"`
-	ReverseDNS       string   `form:"reverse_dns"`
-	Size             string   `form:"size"`
-	Region           string   `form:"region"`
-	PublicIPRequired bool     `form:"public_ip_required"`
-	NetworkID        string   `form:"network_id"`
-	TemplateID       string   `form:"template_id"`
-	SnapshotID       string   `form:"snapshot_id"`
-	InitialUser      string   `form:"initial_user"`
-	SSHKeyID         string   `form:"ssh_key_id"`
-	Script           string   `form:"script"`
-	Tags             []string `form:"-"`
-	TagsList         string   `form:"tags"`
+	Count            int      `json:"count"`
+	Hostname         string   `json:"hostname"`
+	ReverseDNS       string   `json:"reverse_dns"`
+	Size             string   `json:"size"`
+	Region           string   `json:"region"`
+	PublicIPRequired bool     `json:"public_ip_required"`
+	NetworkID        string   `json:"network_id"`
+	TemplateID       string   `json:"template_id"`
+	SnapshotID       string   `json:"snapshot_id"`
+	InitialUser      string   `json:"initial_user"`
+	SSHKeyID         string   `json:"ssh_key_id"`
+	Script           string   `json:"script"`
+	Tags             []string `json:"-"`
+	TagsList         string   `json:"tags"`
 }
 
 // ListInstances returns a page of Instances owned by the calling API account

--- a/instance_test.go
+++ b/instance_test.go
@@ -215,7 +215,7 @@ func TestSetInstanceTags(t *testing.T) {
 func TestUpdateInstance(t *testing.T) {
 	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
 		"/v2/instances/12345": {
-			"requestBody":  `hostname=dummy.example.com&notes=my+notes&reverse_dns=dummy-reverse.example.com`,
+			"requestBody":  `{"hostname":"dummy.example.com","notes":"my notes","reverse_dns":"dummy-reverse.example.com"}`,
 			"method":       "PUT",
 			"responseBody": `{"result": "success"}`,
 		},

--- a/instance_test.go
+++ b/instance_test.go
@@ -232,146 +232,145 @@ func TestUpdateInstance(t *testing.T) {
 	EnsureSuccessfulSimpleResponse(t, got, err)
 }
 
-//
-//func TestDeleteInstance(t *testing.T) {
-//	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
-//		"/v2/instances/12345": {
-//			"requestBody":  ``,
-//			"method":       "DELETE",
-//			"responseBody": `{"result": "success"}`,
-//		},
-//	})
-//	defer server.Close()
-//
-//	got, err := client.DeleteInstance("12345")
-//	EnsureSuccessfulSimpleResponse(t, got, err)
-//}
-//
-//func TestRebootInstance(t *testing.T) {
-//	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
-//		"/v2/instances/12345/hard_reboots": {
-//			"requestBody":  ``,
-//			"method":       "POST",
-//			"responseBody": `{"result": "success"}`,
-//		},
-//	})
-//	defer server.Close()
-//
-//	got, err := client.RebootInstance("12345")
-//	EnsureSuccessfulSimpleResponse(t, got, err)
-//}
-//
-//func TestHardRebootInstance(t *testing.T) {
-//	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
-//		"/v2/instances/12345/hard_reboots": {
-//			"requestBody":  ``,
-//			"method":       "POST",
-//			"responseBody": `{"result": "success"}`,
-//		},
-//	})
-//	defer server.Close()
-//
-//	got, err := client.HardRebootInstance("12345")
-//	EnsureSuccessfulSimpleResponse(t, got, err)
-//}
-//
-//func TestSoftRebootInstance(t *testing.T) {
-//	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
-//		"/v2/instances/12345/soft_reboots": {
-//			"requestBody":  ``,
-//			"method":       "POST",
-//			"responseBody": `{"result": "success"}`,
-//		},
-//	})
-//	defer server.Close()
-//
-//	got, err := client.SoftRebootInstance("12345")
-//	EnsureSuccessfulSimpleResponse(t, got, err)
-//}
-//
-//func TestStopInstance(t *testing.T) {
-//	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
-//		"/v2/instances/12345/stop": {
-//			"requestBody":  ``,
-//			"method":       "PUT",
-//			"responseBody": `{"result": "success"}`,
-//		},
-//	})
-//	defer server.Close()
-//
-//	got, err := client.StopInstance("12345")
-//	EnsureSuccessfulSimpleResponse(t, got, err)
-//}
-//
-//func TestStartInstance(t *testing.T) {
-//	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
-//		"/v2/instances/12345/start": {
-//			"requestBody":  ``,
-//			"method":       "PUT",
-//			"responseBody": `{"result": "success"}`,
-//		},
-//	})
-//	defer server.Close()
-//
-//	got, err := client.StartInstance("12345")
-//	EnsureSuccessfulSimpleResponse(t, got, err)
-//}
-//
-//func TestUpgradeInstance(t *testing.T) {
-//	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
-//		"/v2/instances/12345/resize": {
-//			"requestBody":  `size=g99.huge`,
-//			"method":       "PUT",
-//			"responseBody": `{"result": "success"}`,
-//		},
-//	})
-//	defer server.Close()
-//
-//	got, err := client.UpgradeInstance("12345", "g99.huge")
-//	EnsureSuccessfulSimpleResponse(t, got, err)
-//}
-//
-//func TestMovePublicIPToInstance(t *testing.T) {
-//	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
-//		"/v2/instances/12345/ip/1.2.3.4": {
-//			"requestBody":  ``,
-//			"method":       "PUT",
-//			"responseBody": `{"result": "success"}`,
-//		},
-//	})
-//	defer server.Close()
-//
-//	got, err := client.MovePublicIPToInstance("12345", "1.2.3.4")
-//	EnsureSuccessfulSimpleResponse(t, got, err)
-//}
-//
-//func TestGetInstanceConsoleURL(t *testing.T) {
-//	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
-//		"/v2/instances/12345/console": {
-//			"requestBody":  ``,
-//			"responseBody": `{"url": "https://console.example.com/12345"}`,
-//			"method":       "GET",
-//		},
-//	})
-//	defer server.Close()
-//
-//	got, _ := client.GetInstanceConsoleURL("12345")
-//
-//	if got != "https://console.example.com/12345" {
-//		t.Errorf("Expected %s, got %s", "https://console.example.com/12345", got)
-//	}
-//}
-//
-//func TestSetInstanceFirewall(t *testing.T) {
-//	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
-//		"/v2/instances/12345/firewall": {
-//			"requestBody":  `firewall_id=67890`,
-//			"method":       "PUT",
-//			"responseBody": `{"result": "success"}`,
-//		},
-//	})
-//	defer server.Close()
-//
-//	got, err := client.SetInstanceFirewall("12345", "67890")
-//	EnsureSuccessfulSimpleResponse(t, got, err)
-//}
+func TestDeleteInstance(t *testing.T) {
+	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
+		"/v2/instances/12345": {
+			"requestBody":  ``,
+			"method":       "DELETE",
+			"responseBody": `{"result": "success"}`,
+		},
+	})
+	defer server.Close()
+
+	got, err := client.DeleteInstance("12345")
+	EnsureSuccessfulSimpleResponse(t, got, err)
+}
+
+func TestRebootInstance(t *testing.T) {
+	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
+		"/v2/instances/12345/hard_reboots": {
+			"requestBody":  `""`,
+			"method":       "POST",
+			"responseBody": `{"result": "success"}`,
+		},
+	})
+	defer server.Close()
+
+	got, err := client.RebootInstance("12345")
+	EnsureSuccessfulSimpleResponse(t, got, err)
+}
+
+func TestHardRebootInstance(t *testing.T) {
+	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
+		"/v2/instances/12345/hard_reboots": {
+			"requestBody":  `""`,
+			"method":       "POST",
+			"responseBody": `{"result": "success"}`,
+		},
+	})
+	defer server.Close()
+
+	got, err := client.HardRebootInstance("12345")
+	EnsureSuccessfulSimpleResponse(t, got, err)
+}
+
+func TestSoftRebootInstance(t *testing.T) {
+	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
+		"/v2/instances/12345/soft_reboots": {
+			"requestBody":  `""`,
+			"method":       "POST",
+			"responseBody": `{"result": "success"}`,
+		},
+	})
+	defer server.Close()
+
+	got, err := client.SoftRebootInstance("12345")
+	EnsureSuccessfulSimpleResponse(t, got, err)
+}
+
+func TestStopInstance(t *testing.T) {
+	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
+		"/v2/instances/12345/stop": {
+			"requestBody":  `""`,
+			"method":       "PUT",
+			"responseBody": `{"result": "success"}`,
+		},
+	})
+	defer server.Close()
+
+	got, err := client.StopInstance("12345")
+	EnsureSuccessfulSimpleResponse(t, got, err)
+}
+
+func TestStartInstance(t *testing.T) {
+	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
+		"/v2/instances/12345/start": {
+			"requestBody":  `""`,
+			"method":       "PUT",
+			"responseBody": `{"result": "success"}`,
+		},
+	})
+	defer server.Close()
+
+	got, err := client.StartInstance("12345")
+	EnsureSuccessfulSimpleResponse(t, got, err)
+}
+
+func TestUpgradeInstance(t *testing.T) {
+	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
+		"/v2/instances/12345/resize": {
+			"requestBody":  `{"size":"g99.huge"}`,
+			"method":       "PUT",
+			"responseBody": `{"result": "success"}`,
+		},
+	})
+	defer server.Close()
+
+	got, err := client.UpgradeInstance("12345", "g99.huge")
+	EnsureSuccessfulSimpleResponse(t, got, err)
+}
+
+func TestMovePublicIPToInstance(t *testing.T) {
+	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
+		"/v2/instances/12345/ip/1.2.3.4": {
+			"requestBody":  `""`,
+			"method":       "PUT",
+			"responseBody": `{"result": "success"}`,
+		},
+	})
+	defer server.Close()
+
+	got, err := client.MovePublicIPToInstance("12345", "1.2.3.4")
+	EnsureSuccessfulSimpleResponse(t, got, err)
+}
+
+func TestGetInstanceConsoleURL(t *testing.T) {
+	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
+		"/v2/instances/12345/console": {
+			"requestBody":  `""`,
+			"responseBody": `{"url": "https://console.example.com/12345"}`,
+			"method":       "GET",
+		},
+	})
+	defer server.Close()
+
+	got, _ := client.GetInstanceConsoleURL("12345")
+
+	if got != "https://console.example.com/12345" {
+		t.Errorf("Expected %s, got %s", "https://console.example.com/12345", got)
+	}
+}
+
+func TestSetInstanceFirewall(t *testing.T) {
+	client, server, _ := NewAdvancedClientForTesting(map[string]map[string]string{
+		"/v2/instances/12345/firewall": {
+			"requestBody":  `{"firewall_id":"67890"}`,
+			"method":       "PUT",
+			"responseBody": `{"result": "success"}`,
+		},
+	})
+	defer server.Close()
+
+	got, err := client.SetInstanceFirewall("12345", "67890")
+	EnsureSuccessfulSimpleResponse(t, got, err)
+}

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -61,12 +61,12 @@ type KubernetesCluster struct {
 
 // KubernetesClusterConfig is used to create a new cluster
 type KubernetesClusterConfig struct {
-	Name              string `form:"name"`
-	NumTargetNodes    int    `form:"num_target_nodes"`
-	TargetNodesSize   string `form:"target_nodes_size"`
-	KubernetesVersion string `form:"kubernetes_version"`
-	Tags              string `form:"tags"`
-	Applications      string `form:"applications"`
+	Name              string `json:"name"`
+	NumTargetNodes    int    `json:"num_target_nodes"`
+	TargetNodesSize   string `json:"target_nodes_size"`
+	KubernetesVersion string `json:"kubernetes_version"`
+	Tags              string `json:"tags"`
+	Applications      string `json:"applications"`
 }
 
 // KubernetesPlanConfiguration is a value within a configuration for

--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -16,9 +16,9 @@ type LoadBalancerBackend struct {
 
 // LoadBalancerBackendConfig is the configuration for creating backends
 type LoadBalancerBackendConfig struct {
-	InstanceID string `from:"instance_id"`
-	Protocol   string `from:"protocol"`
-	Port       int    `from:"port"`
+	InstanceID string `json:"instance_id"`
+	Protocol   string `json:"protocol"`
+	Port       int    `json:"port"`
 }
 
 // LoadBalancer represents a load balancer configuration within Civo
@@ -41,18 +41,18 @@ type LoadBalancer struct {
 
 // LoadBalancerConfig represents a load balancer to be created
 type LoadBalancerConfig struct {
-	Hostname                string `from:"hostname"`
-	Protocol                string `from:"protocol"`
-	TLSCertificate          string `from:"tls_certificate"`
-	TLSKey                  string `from:"tls_key"`
-	Policy                  string `from:"policy"`
-	Port                    int    `from:"port"`
-	MaxRequestSize          int    `from:"max_request_size"`
-	HealthCheckPath         string `from:"health_check_path"`
-	FailTimeout             int    `from:"fail_timeout"`
-	MaxConns                int    `from:"max_conns"`
-	IgnoreInvalidBackendTLS bool   `from:"ignore_invalid_backend_tls"`
-	Backends                []LoadBalancerBackendConfig
+	Hostname                string                      `json:"hostname"`
+	Protocol                string                      `json:"protocol"`
+	TLSCertificate          string                      `json:"tls_certificate"`
+	TLSKey                  string                      `json:"tls_key"`
+	Policy                  string                      `json:"policy"`
+	Port                    int                         `json:"port"`
+	MaxRequestSize          int                         `json:"max_request_size"`
+	HealthCheckPath         string                      `json:"health_check_path"`
+	FailTimeout             int                         `json:"fail_timeout"`
+	MaxConns                int                         `json:"max_conns"`
+	IgnoreInvalidBackendTLS bool                        `json:"ignore_invalid_backend_tls"`
+	Backends                []LoadBalancerBackendConfig `json:"backends"`
 }
 
 // ListLoadBalancers returns all load balancers owned by the calling API account

--- a/network.go
+++ b/network.go
@@ -19,7 +19,7 @@ type Network struct {
 }
 
 type networkConfig struct {
-	Label string `form:"label"`
+	Label string `json:"label"`
 }
 
 // NetworkResult represents the result from a network create/update call

--- a/snapshot.go
+++ b/snapshot.go
@@ -26,7 +26,7 @@ type Snapshot struct {
 
 // SnapshotConfig represents the options required for creating a new snapshot
 type SnapshotConfig struct {
-	InstanceID string `form:"instance_id"`
+	InstanceID string `json:"instance_id"`
 	Safe       bool   `from:"safe"`
 	Cron       string `from:"cron_timing"`
 }

--- a/volume.go
+++ b/volume.go
@@ -29,9 +29,9 @@ type VolumeResult struct {
 
 // VolumeConfig are the settings required to create a new Volume
 type VolumeConfig struct {
-	Name          string `form:"name"`
-	SizeGigabytes int    `form:"size_gb"`
-	Bootable      bool   `form:"bootable"`
+	Name          string `json:"name"`
+	SizeGigabytes int    `json:"size_gb"`
+	Bootable      bool   `json:"bootable"`
 }
 
 // ListVolumes returns all volumes owned by the calling API account

--- a/webhook.go
+++ b/webhook.go
@@ -20,9 +20,9 @@ type Webhook struct {
 
 // WebhookConfig represents the options required for creating a new webhook
 type WebhookConfig struct {
-	Events []string `form:"events"`
-	URL    string   `form:"url"`
-	Secret string   `form:"secret"`
+	Events []string `json:"events"`
+	URL    string   `json:"url"`
+	Secret string   `json:"secret"`
 }
 
 // CreateWebhook creates a new webhook


### PR DESCRIPTION
Now you can rename a firewall using `RenameFirewall` function, It is no
longer necessary to delete the firewall to rename it