### PR TITLE
add rename endpoint for firewall

### DIFF
--- a/firewall.go
+++ b/firewall.go
@@ -107,6 +107,18 @@ func (c *Client) NewFirewall(name string) (*FirewallResult, error) {
 	return result, nil
 }
 
+// RenameFirewall rename firewall
+func (c *Client) RenameFirewall(id string, name string) (*SimpleResponse, error) {
+	resp, err := c.SendPutRequest(fmt.Sprintf("/v2/firewalls/%s", id), map[string]string{
+		"name": name,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return c.DecodeSimpleResponse(resp)
+}
+
 // DeleteFirewall deletes an firewall
 func (c *Client) DeleteFirewall(id string) (*SimpleResponse, error) {
 	resp, err := c.SendDeleteRequest("/v2/firewalls/" + id)

--- a/firewall_test.go
+++ b/firewall_test.go
@@ -94,6 +94,23 @@ func TestNewFirewall(t *testing.T) {
 	}
 }
 
+func TestRenameFirewall(t *testing.T) {
+	client, server, _ := NewClientForTesting(map[string]string{
+		"/v2/firewalls/12346": `{"result": "success"}`,
+	})
+	defer server.Close()
+	got, err := client.RenameFirewall("12346", "new_name")
+	if err != nil {
+		t.Errorf("Request returned an error: %s", err)
+		return
+	}
+
+	expected := &SimpleResponse{Result: "success"}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("Expected %+v, got %+v", expected, got)
+	}
+}
+
 func TestDeleteFirewall(t *testing.T) {
 	client, server, _ := NewClientForTesting(map[string]string{
 		"/v2/firewalls/12346": `{"result": "success"}`,


### PR DESCRIPTION
Now you can rename a firewall using RenameFirewall function, It is no
longer necessary to delete the firewall to rename it

BREAKING CHANGE: No

Signed-off-by: Alejandro JNM <alejandrojnm@gmail.com>