### PR TITLE
Add new option to ssh

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,6 +37,7 @@ type Result string
 
 // SimpleResponse is a structure that returns success and/or any error
 type SimpleResponse struct {
+	ID           string `json:"id"`
 	Result       Result `json:"result"`
 	ErrorCode    string `json:"code"`
 	ErrorReason  string `json:"reason"`

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/civo/civogo
 
 go 1.13
-
-require github.com/ajg/form v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
-github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=

--- a/instance.go
+++ b/instance.go
@@ -141,14 +141,6 @@ func (c *Client) GetInstance(id string) (*Instance, error) {
 
 // NewInstanceConfig returns an initialized config for a new instance
 func (c *Client) NewInstanceConfig() (*InstanceConfig, error) {
-	var sshKeyID string
-	sshKey, err := c.GetDefaultSSHKey()
-	if err == nil {
-		sshKeyID = sshKey.ID
-	} else {
-		sshKeyID = ""
-	}
-
 	network, err := c.GetDefaultNetwork()
 	if err != nil {
 		return nil, err
@@ -170,7 +162,7 @@ func (c *Client) NewInstanceConfig() (*InstanceConfig, error) {
 		TemplateID:       template.ID,
 		SnapshotID:       "",
 		InitialUser:      "civo",
-		SSHKeyID:         sshKeyID,
+		SSHKeyID:         "",
 		Script:           "",
 		Tags:             []string{""},
 	}, nil

--- a/instance_test.go
+++ b/instance_test.go
@@ -124,9 +124,6 @@ func TestNewInstanceConfig(t *testing.T) {
 	if got.TemplateID != "3" {
 		t.Errorf("Expected %s, got %s", "3", got.TemplateID)
 	}
-	if got.SSHKeyID != "4" {
-		t.Errorf("Expected %s, got %s", "3", got.TemplateID)
-	}
 	if got.Count != 1 {
 		t.Errorf("Expected %d, got %d", 1, got.Count)
 	}

--- a/ssh_key.go
+++ b/ssh_key.go
@@ -29,7 +29,7 @@ func (c *Client) ListSSHKeys() ([]SSHKey, error) {
 	return sshKeys, nil
 }
 
-// NewSSHKey creates a new ssh key record
+// NewSSHKey creates a new SSH key record
 func (c *Client) NewSSHKey(name string, publicKey string) (*SimpleResponse, error) {
 	resp, err := c.SendPostRequest("/v2/sshkeys", map[string]string{
 		"name":       name,
@@ -42,9 +42,9 @@ func (c *Client) NewSSHKey(name string, publicKey string) (*SimpleResponse, erro
 	return c.DecodeSimpleResponse(resp)
 }
 
-// UpdateSSHKey update a ssk key record
-func (c *Client) UpdateSSHKey(name string, sshID string) (*SSHKey, error) {
-	resp, err := c.SendPutRequest(fmt.Sprintf("/v2/sshkeys/%s", sshID), map[string]string{
+// UpdateSSHKey update a SSH key record
+func (c *Client) UpdateSSHKey(name string, sshKeyID string) (*SSHKey, error) {
+	resp, err := c.SendPutRequest(fmt.Sprintf("/v2/sshkeys/%s", sshKeyID), map[string]string{
 		"name": name,
 	})
 	if err != nil {
@@ -84,7 +84,7 @@ func (c *Client) FindSSHKey(search string) (*SSHKey, error) {
 	return &keys[found], nil
 }
 
-// DeleteFirewallRule deletes an firewall
+// DeleteSSHKey deletes an SSH key
 func (c *Client) DeleteSSHKey(id string) (*SimpleResponse, error) {
 	resp, err := c.SendDeleteRequest(fmt.Sprintf("/v2/sshkeys/%s", id))
 	if err != nil {

--- a/ssh_key.go
+++ b/ssh_key.go
@@ -9,70 +9,66 @@ import (
 
 // SSHKey represents an SSH public key, uploaded to access instances
 type SSHKey struct {
-	ID      string `json:"id"`
-	Name    string `json:"name"`
-	Region  string `json:"region"`
-	Default bool   `json:"default"`
-	CIDR    string `json:"cidr"`
-	Label   string `json:"label"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	FingerPrint string `json:"fingerprint"`
 }
 
-// PaginatedSSHKeyList returns a paginated list of SSHKey objects
-type PaginatedSSHKeyList struct {
-	Page    int      `json:"page"`
-	PerPage int      `json:"per_page"`
-	Pages   int      `json:"pages"`
-	Items   []SSHKey `json:"items"`
-}
-
-// ListSSHKeys finds the default private SSH key for an account
-func (c *Client) ListSSHKeys(page int, perPage int) (PaginatedSSHKeyList, error) {
-	url := "/v2/sshkeys"
-	if page != 0 && perPage != 0 {
-		url = url + fmt.Sprintf("?page=%d&per_page=%d", page, perPage)
-	}
-
-	PaginatedSSHKeys := PaginatedSSHKeyList{}
-
-	resp, err := c.SendGetRequest(url)
-	if err != nil {
-		return PaginatedSSHKeys, err
-	}
-
-	err = json.NewDecoder(bytes.NewReader(resp)).Decode(&PaginatedSSHKeys)
-	if err != nil {
-		return PaginatedSSHKeys, err
-	}
-
-	return PaginatedSSHKeys, nil
-}
-
-// GetDefaultSSHKey finds the default private SSH key for an account
-func (c *Client) GetDefaultSSHKey() (*SSHKey, error) {
-	keys, err := c.ListSSHKeys(1, 9999999)
+// ListSSHKeys list all SSH key for an account
+func (c *Client) ListSSHKeys() ([]SSHKey, error) {
+	resp, err := c.SendGetRequest("/v2/sshkeys")
 	if err != nil {
 		return nil, err
 	}
 
-	for _, key := range keys.Items {
-		if key.Default {
-			return &key, nil
-		}
+	sshKeys := make([]SSHKey, 0)
+	if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&sshKeys); err != nil {
+		return nil, err
 	}
 
-	return nil, fmt.Errorf("default SSH key not found")
+	return sshKeys, nil
+}
+
+// NewSSHKey creates a new ssh key record
+func (c *Client) NewSSHKey(name string, publicKey string) (*SimpleResponse, error) {
+	resp, err := c.SendPostRequest("/v2/sshkeys", map[string]string{
+		"name":       name,
+		"public_key": publicKey,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return c.DecodeSimpleResponse(resp)
+}
+
+// UpdateSSHKey update a ssk key record
+func (c *Client) UpdateSSHKey(name string, sshID string) (*SSHKey, error) {
+	resp, err := c.SendPutRequest(fmt.Sprintf("/v2/sshkeys/%s", sshID), map[string]string{
+		"name": name,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result := &SSHKey{}
+	if err := json.NewDecoder(bytes.NewReader(resp)).Decode(result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
 // FindSSHKey finds a SSH key by either part of the ID or part of the name
 func (c *Client) FindSSHKey(search string) (*SSHKey, error) {
-	keys, err := c.ListSSHKeys(1, 99999999)
+	keys, err := c.ListSSHKeys()
 	if err != nil {
 		return nil, err
 	}
 
 	found := -1
 
-	for i, key := range keys.Items {
+	for i, key := range keys {
 		if strings.Contains(key.ID, search) || strings.Contains(key.Name, search) {
 			if found != -1 {
 				return nil, fmt.Errorf("unable to find %s because there were multiple matches", search)
@@ -85,5 +81,15 @@ func (c *Client) FindSSHKey(search string) (*SSHKey, error) {
 		return nil, fmt.Errorf("unable to find %s, zero matches", search)
 	}
 
-	return &keys.Items[found], nil
+	return &keys[found], nil
+}
+
+// DeleteFirewallRule deletes an firewall
+func (c *Client) DeleteSSHKey(id string) (*SimpleResponse, error) {
+	resp, err := c.SendDeleteRequest(fmt.Sprintf("/v2/sshkeys/%s", id))
+	if err != nil {
+		return nil, err
+	}
+
+	return c.DecodeSimpleResponse(resp)
 }


### PR DESCRIPTION
Now you can create, update and delete the ssh keys, at the same time we add ID to the client to return the ID when the backend does it, as in the case of creating an ssh key