### PR TITLE
Use new GitHub Actions syntax

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,8 @@ jobs:
       uses: actions/checkout@v1
     - name: setup env
       run: |
-        echo "::set-env name=GOPATH::$(go env GOPATH)"
-        echo "::add-path::$(go env GOPATH)/bin"
+        echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       shell: bash
     - name: lint
       run: |


### PR DESCRIPTION
This will address the new syntax mentioned in: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Causing: Error: Unable to process command '::set-env name=GOPATH::/home/runner/go' successfully.

See: https://github.com/actions/toolkit/blob/main/docs/commands.md#environment-files

Fixes: civo/civogo#47