### PR TITLE
Clusternames should be considered case insensitive

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -148,10 +148,10 @@ func (c *Client) FindKubernetesCluster(search string) (*KubernetesCluster, error
 	result := KubernetesCluster{}
 
 	for _, value := range clusters.Items {
-		if value.Name == search || value.ID == search {
+		if strings.EqualFold(value.Name, search) || value.ID == search {
 			exactMatch = true
 			result = value
-		} else if strings.Contains(value.Name, search) || strings.Contains(value.ID, search) {
+		} else if strings.Contains(strings.ToUpper(value.Name), strings.ToUpper(search)) || strings.Contains(value.ID, search) {
 			if exactMatch == false {
 				result = value
 				partialMatchesCount++

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -140,6 +140,11 @@ func TestFindKubernetesCluster(t *testing.T) {
 		t.Errorf("Expected %s, got %s", "69a23478-a89e-41d2-97b1-6f4c341cee70", got.ID)
 	}
 
+	got, _ = client.FindKubernetesCluster("YOUR-FIRST-CLUSTER-NAME")
+	if got.ID != "69a23478-a89e-41d2-97b1-6f4c341cee70" {
+		t.Errorf("Expected %s, got %s", "69a23478-a89e-41d2-97b1-6f4c341cee70", got.ID)
+	}
+
 	got, _ = client.FindKubernetesCluster("second")
 	if got.ID != "d1cd0b71-5da1-492e-9d0d-a46ccdaae2fa" {
 		t.Errorf("Expected %s, got %s", "d1cd0b71-5da1-492e-9d0d-a46ccdaae2fa", got.ID)


### PR DESCRIPTION
This commit makes the following changes:
* FindKubernetesCluster is case insensitive now
* Test FindKubernetesCluster for case insensitivity

The current implementation is not optimal though, as the fuzzy matching does not fully support Unicode.
However this should fix most issues for now.