### PR TITLE
Case insensitive region finding

### DIFF
--- a/region.go
+++ b/region.go
@@ -51,12 +51,16 @@ func (c *Client) FindRegion(search string) (*Region, error) {
 	exactMatch := false
 	partialMatchesCount := 0
 	result := Region{}
+	search = strings.ToUpper(search)
 
 	for _, value := range allregion {
-		if value.Name == search || value.Code == search {
+		name := strings.ToUpper(value.Name)
+		code := strings.ToUpper(value.Code)
+
+		if name == search || code == search {
 			exactMatch = true
 			result = value
-		} else if strings.Contains(value.Name, search) || strings.Contains(value.Code, search) {
+		} else if strings.Contains(name, search) || strings.Contains(code, search) {
 			if !exactMatch {
 				result = value
 				partialMatchesCount++

--- a/region.go
+++ b/region.go
@@ -53,10 +53,10 @@ func (c *Client) FindRegion(search string) (*Region, error) {
 	result := Region{}
 
 	for _, value := range allregion {
-		if value.Name == search || value.Code == search || value.Country == search {
+		if value.Name == search || value.Code == search {
 			exactMatch = true
 			result = value
-		} else if strings.Contains(value.Name, search) || strings.Contains(value.Code, search) || strings.Contains(value.Country, search) {
+		} else if strings.Contains(value.Name, search) || strings.Contains(value.Code, search) {
 			if !exactMatch {
 				result = value
 				partialMatchesCount++


### PR DESCRIPTION
When using the CLI the command `civo create k3s --region=lon1` doesn't work, but with `LON1` it works. Regions should be case insensitive when searching.

After this is approved and merged, can the merger please update civo/cli to use the new version.