### PR TITLE
Add new struct fields for cluster firewall

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -109,8 +109,7 @@ type KubernetesClusterConfig struct {
 	Pools             []KubernetesClusterPoolConfig `json:"pools,omitempty"`
 	Applications      string                        `json:"applications,omitempty"`
 	InstanceFirewall  string                        `json:"instance_firewall,omitempty"`
-	FirewallRule      []string                      `json:"firewall_rule,omitempty"`
-	CurrentIP         string                        `json:"current_ip,omitempty"`
+	FirewallRule      string                        `json:"firewall_rule,omitempty"`
 }
 
 //KubernetesClusterPoolConfig is used to create a new cluster pool

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -85,6 +85,7 @@ type KubernetesCluster struct {
 	Instances             []KubernetesInstance             `json:"instances,omitempty"`
 	Pools                 []KubernetesPool                 `json:"pools,omitempty"`
 	InstalledApplications []KubernetesInstalledApplication `json:"installed_applications,omitempty"`
+	FirewallID            string                           `json:"firewall_id,omitempty"`
 }
 
 // PaginatedKubernetesClusters is a Kubernetes k3s cluster

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -107,6 +107,9 @@ type KubernetesClusterConfig struct {
 	Tags              string                        `json:"tags,omitempty"`
 	Pools             []KubernetesClusterPoolConfig `json:"pools,omitempty"`
 	Applications      string                        `json:"applications,omitempty"`
+	InstanceFirewall  string                        `json:"instance_firewall,omitempty"`
+	FirewallRule      []string                      `json:"firewall_rule,omitempty"`
+	CurrentIP         string                        `json:"current_ip,omitempty"`
 }
 
 //KubernetesClusterPoolConfig is used to create a new cluster pool

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -24,6 +24,7 @@ func TestListKubernetesClusters(t *testing.T) {
 		  "dns_entry": "69a23478-a89e-41d2-97b1-6f4c341cee70.k8s.civo.com",
 		  "tags": [],
 		  "created_at": "2019-09-23T13:02:59.000+01:00",
+		  "firewall_id": "42118911-44c2-4cab-ad77-bcae062815b3",
 		  "instances": [{
 			"hostname": "kube-master-HEXDIGITS",
 			"size": "g2.xsmall",
@@ -85,6 +86,7 @@ func TestListKubernetesClusters(t *testing.T) {
 				DNSEntry:          "69a23478-a89e-41d2-97b1-6f4c341cee70.k8s.civo.com",
 				CreatedAt:         createAt,
 				Tags:              []string{},
+				FirewallID:        "42118911-44c2-4cab-ad77-bcae062815b3",
 				Instances: []KubernetesInstance{{
 					Hostname:   "kube-master-HEXDIGITS",
 					Size:       "g2.xsmall",
@@ -119,8 +121,8 @@ func TestListKubernetesClusters(t *testing.T) {
 func TestFindKubernetesCluster(t *testing.T) {
 	client, server, _ := NewClientForTesting(map[string]string{
 		"/v2/kubernetes/clusters": `{"page":1,"per_page":20,"pages":1,"items":[
-			{ "id": "69a23478-a89e-41d2-97b1-6f4c341cee70", "name": "your-first-cluster-name", "version": "2", "status": "ACTIVE", "ready": true, "num_target_nodes": 1, "target_nodes_size": "g2.xsmall", "built_at": "2019-09-23T13:04:23.000+01:00", "kubeconfig": "YAML_VERSION_OF_KUBECONFIG_HERE\n", "kubernetes_version": "0.8.1", "api_endpoint": "https://your.cluster.ip.address:6443", "dns_entry": "69a23478-a89e-41d2-97b1-6f4c341cee70.k8s.civo.com", "tags": [], "created_at": "2019-09-23T13:02:59.000+01:00", "instances": [{ "hostname": "kube-master-HEXDIGITS", "size": "g2.xsmall", "region": "lon1", "created_at": "2019-09-23T13:03:00.000+01:00", "status": "ACTIVE", "firewall_id": "5f0ba9ed-5ca7-4e14-9a09-449a84196d64", "public_ip": "your.cluster.ip.address", "tags": ["civo-kubernetes:installed", "civo-kubernetes:master"] }], "installed_applications": [{ "application": "Traefik", "title": null, "version": "(default)", "dependencies": null, "maintainer": "@Rancher_Labs", "description": "A reverse proxy/load-balancer that's easy, dynamic, automatic, fast, full-featured, open source, production proven and provides metrics.", "post_install": "Some documentation here\n", "installed": true, "url": "https://traefik.io", "category": "architecture", "updated_at": "2019-09-23T13:02:59.000+01:00", "image_url": "https://api.civo.com/k3s-marketplace/traefik.png", "plan": null, "configuration": {} }] },
-			{ "id": "d1cd0b71-5da1-492e-9d0d-a46ccdaae2fa", "name": "your-second-cluster-name", "version": "2", "status": "ACTIVE", "ready": true, "num_target_nodes": 1, "target_nodes_size": "g2.xsmall", "built_at": "2019-09-23T13:04:23.000+01:00", "kubeconfig": "YAML_VERSION_OF_KUBECONFIG_HERE\n", "kubernetes_version": "0.8.1", "api_endpoint": "https://your.cluster.ip.address:6443", "dns_entry": "69a23478-a89e-41d2-97b1-6f4c341cee70.k8s.civo.com", "tags": [], "created_at": "2019-09-23T13:02:59.000+01:00", "instances": [{ "hostname": "kube-master-HEXDIGITS", "size": "g2.xsmall", "region": "lon1", "created_at": "2019-09-23T13:03:00.000+01:00", "status": "ACTIVE", "firewall_id": "5f0ba9ed-5ca7-4e14-9a09-449a84196d64", "public_ip": "your.cluster.ip.address", "tags": ["civo-kubernetes:installed", "civo-kubernetes:master"] }], "installed_applications": [{ "application": "Traefik", "title": null, "version": "(default)", "dependencies": null, "maintainer": "@Rancher_Labs", "description": "A reverse proxy/load-balancer that's easy, dynamic, automatic, fast, full-featured, open source, production proven and provides metrics.", "post_install": "Some documentation here\n", "installed": true, "url": "https://traefik.io", "category": "architecture", "updated_at": "2019-09-23T13:02:59.000+01:00", "image_url": "https://api.civo.com/k3s-marketplace/traefik.png", "plan": null, "configuration": {} }] }
+			{ "id": "69a23478-a89e-41d2-97b1-6f4c341cee70", "name": "your-first-cluster-name", "version": "2", "status": "ACTIVE", "ready": true, "num_target_nodes": 1, "target_nodes_size": "g2.xsmall", "built_at": "2019-09-23T13:04:23.000+01:00", "kubeconfig": "YAML_VERSION_OF_KUBECONFIG_HERE\n", "kubernetes_version": "0.8.1", "api_endpoint": "https://your.cluster.ip.address:6443", "dns_entry": "69a23478-a89e-41d2-97b1-6f4c341cee70.k8s.civo.com", "tags": [], "created_at": "2019-09-23T13:02:59.000+01:00", "firewall_id": "42118911-44c2-4cab-ad77-bcae062815b3", "instances": [{ "hostname": "kube-master-HEXDIGITS", "size": "g2.xsmall", "region": "lon1", "created_at": "2019-09-23T13:03:00.000+01:00", "status": "ACTIVE", "firewall_id": "5f0ba9ed-5ca7-4e14-9a09-449a84196d64", "public_ip": "your.cluster.ip.address", "tags": ["civo-kubernetes:installed", "civo-kubernetes:master"] }], "installed_applications": [{ "application": "Traefik", "title": null, "version": "(default)", "dependencies": null, "maintainer": "@Rancher_Labs", "description": "A reverse proxy/load-balancer that's easy, dynamic, automatic, fast, full-featured, open source, production proven and provides metrics.", "post_install": "Some documentation here\n", "installed": true, "url": "https://traefik.io", "category": "architecture", "updated_at": "2019-09-23T13:02:59.000+01:00", "image_url": "https://api.civo.com/k3s-marketplace/traefik.png", "plan": null, "configuration": {} }] },
+			{ "id": "d1cd0b71-5da1-492e-9d0d-a46ccdaae2fa", "name": "your-second-cluster-name", "version": "2", "status": "ACTIVE", "ready": true, "num_target_nodes": 1, "target_nodes_size": "g2.xsmall", "built_at": "2019-09-23T13:04:23.000+01:00", "kubeconfig": "YAML_VERSION_OF_KUBECONFIG_HERE\n", "kubernetes_version": "0.8.1", "api_endpoint": "https://your.cluster.ip.address:6443", "dns_entry": "69a23478-a89e-41d2-97b1-6f4c341cee70.k8s.civo.com", "tags": [], "created_at": "2019-09-23T13:02:59.000+01:00", "firewall_id": "42118911-44c2-4cab-ad77-bcae062815b3", "instances": [{ "hostname": "kube-master-HEXDIGITS", "size": "g2.xsmall", "region": "lon1", "created_at": "2019-09-23T13:03:00.000+01:00", "status": "ACTIVE", "firewall_id": "5f0ba9ed-5ca7-4e14-9a09-449a84196d64", "public_ip": "your.cluster.ip.address", "tags": ["civo-kubernetes:installed", "civo-kubernetes:master"] }], "installed_applications": [{ "application": "Traefik", "title": null, "version": "(default)", "dependencies": null, "maintainer": "@Rancher_Labs", "description": "A reverse proxy/load-balancer that's easy, dynamic, automatic, fast, full-featured, open source, production proven and provides metrics.", "post_install": "Some documentation here\n", "installed": true, "url": "https://traefik.io", "category": "architecture", "updated_at": "2019-09-23T13:02:59.000+01:00", "image_url": "https://api.civo.com/k3s-marketplace/traefik.png", "plan": null, "configuration": {} }] }
 		]}`,
 	})
 	defer server.Close()
@@ -179,6 +181,7 @@ func TestNewKubernetesClusters(t *testing.T) {
 		  "dns_entry": "69a23478-a89e-41d2-97b1-6f4c341cee70.k8s.civo.com",
 		  "tags": [],
 		  "created_at": "2019-09-23T13:02:59.000+01:00",
+		  "firewall_id": "42118911-44c2-4cab-ad77-bcae062815b3",
 		  "instances": [{
 			"hostname": "kube-master-HEXDIGITS",
 			"size": "g2.xsmall",
@@ -245,6 +248,7 @@ func TestNewKubernetesClusters(t *testing.T) {
 		DNSEntry:          "69a23478-a89e-41d2-97b1-6f4c341cee70.k8s.civo.com",
 		CreatedAt:         createAt,
 		Tags:              []string{},
+		FirewallID:        "42118911-44c2-4cab-ad77-bcae062815b3",
 		Instances: []KubernetesInstance{{
 			Hostname:   "kube-master-HEXDIGITS",
 			Size:       "g2.xsmall",
@@ -293,6 +297,7 @@ func TestGetKubernetesClusters(t *testing.T) {
 		  "dns_entry": "69a23478-a89e-41d2-97b1-6f4c341cee70.k8s.civo.com",
 		  "tags": [],
 		  "created_at": "2019-09-23T13:02:59.000+01:00",
+		  "firewall_id": "42118911-44c2-4cab-ad77-bcae062815b3",
 		  "instances": [{
 			"hostname": "kube-master-HEXDIGITS",
 			"size": "g2.xsmall",
@@ -350,6 +355,7 @@ func TestGetKubernetesClusters(t *testing.T) {
 		DNSEntry:          "69a23478-a89e-41d2-97b1-6f4c341cee70.k8s.civo.com",
 		CreatedAt:         createAt,
 		Tags:              []string{},
+		FirewallID:        "42118911-44c2-4cab-ad77-bcae062815b3",
 		Instances: []KubernetesInstance{{
 			Hostname:   "kube-master-HEXDIGITS",
 			Size:       "g2.xsmall",
@@ -398,6 +404,7 @@ func TestUpdateKubernetesClusters(t *testing.T) {
 		  "dns_entry": "69a23478-a89e-41d2-97b1-6f4c341cee70.k8s.civo.com",
 		  "tags": [],
 		  "created_at": "2019-09-23T13:02:59.000+01:00",
+		  "firewall_id": "42118911-44c2-4cab-ad77-bcae062815b3",
 		  "instances": [{
 			"hostname": "kube-master-HEXDIGITS",
 			"size": "g2.xsmall",
@@ -460,6 +467,7 @@ func TestUpdateKubernetesClusters(t *testing.T) {
 		DNSEntry:          "69a23478-a89e-41d2-97b1-6f4c341cee70.k8s.civo.com",
 		CreatedAt:         createAt,
 		Tags:              []string{},
+		FirewallID:        "42118911-44c2-4cab-ad77-bcae062815b3",
 		Instances: []KubernetesInstance{{
 			Hostname:   "kube-master-HEXDIGITS",
 			Size:       "g2.xsmall",


### PR DESCRIPTION
* Added a new field in `KubernetesCluster` struct to reflect `firewall_id` field returned by API
* Added a new fields in `KubernetesClusterConfig` struct to reflect new optional fields needed by [API](https://www.civo.com/api/kubernetes#create-a-cluster) when creating cluster:
    * `instance_firewall` (string)
    * `firewall_rule` (string)

---

Needed by:

- https://github.com/civo/terraform-provider-civo/issues/35
- https://github.com/civo/terraform-provider-civo/pull/73
- https://github.com/civo/cli/issues/125
- https://github.com/civo/cli/pull/126