### PR TITLE
Outdated link to api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Civogo is a Go client library for accessing the Civo cloud API.
 
-You can view the client API docs at [https://pkg.go.dev/github.com/civo/civogo](https://pkg.go.dev/github.com/civo/civogo) and view the API documentation at [https://api.civo.com](https://api.civo.com)
+You can view the client API docs at [https://pkg.go.dev/github.com/civo/civogo](https://pkg.go.dev/github.com/civo/civogo) and view the API documentation at [https://civo.com/api](https://civo.com/api)
 
 
 ## Install


### PR DESCRIPTION
Fixed link to API docs to valid one: https://civo.com/api