### PR TITLE
Update README to reflect that a new client needs a region code as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,15 @@ go get github.com/civo/civogo
 import "github.com/civo/civogo"
 ```
 
-From there you create a Civo client specifying your API key and use public methods to interact with Civo's API.
+From there you create a Civo client specifying your API key and a region. Then you can use public methods to interact with Civo's API.
 
 ### Authentication
 
+You will need both an API key and a region code to create a new client.
+
 Your API key is listed within the [Civo control panel's security page](https://www.civo.com/account/security). You can also reset the token there, for example, if accidentally put it in source code and found it had been leaked.
 
-You can then use your API key to create a new client:
+For the region code, use any region you know exists, e.g. `LON1`. See the [API documentation](https://github.com/civo/civogo.git) for details.
 
 ```go
 package main
@@ -39,10 +41,11 @@ import (
 
 const (
     apiKey = "mykeygoeshere"
+    regionCode = "LON1"
 )
 
 func main() {
-  client, err := civogo.NewClient(apiKey)
+  client, err := civogo.NewClient(apiKey, regionCode)
   // ...
 }
 ```


### PR DESCRIPTION
Hi, maintainers! Thanks for your dope go client!

Today, I spent a bunch of time trying to determine if there was a way to get a civogo client without specifying a region, and whether the region to be passed to `client.New` was the region `code`, the region `name`, or something else.

It's a bit odd to me that the civo client is region specific - for example,  in order to get a client to list all civo regions, you have to create a client with a known region first, and then call ListRegions. I'm sure y'all have good reasons for this though.



