### PR TITLE
Add function to find teams and remove link between team and organisation

### DIFF
--- a/fake_client.go
+++ b/fake_client.go
@@ -1360,13 +1360,12 @@ func (c *FakeClient) ListTeams() ([]Team, error) {
 }
 
 // CreateTeam implemented in a fake way for automated tests
-func (c *FakeClient) CreateTeam(name, organisationID, accountID string) (*Team, error) {
+func (c *FakeClient) CreateTeam(name string) (*Team, error) {
 	team := Team{
-		ID:             c.generateID(),
-		Name:           name,
-		OrganisationID: organisationID,
-		CreatedAt:      time.Time{},
-		UpdatedAt:      time.Time{},
+		ID:        c.generateID(),
+		Name:      name,
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
 	}
 	c.OrganisationTeams = append(c.OrganisationTeams, team)
 	return &team, nil

--- a/permission.go
+++ b/permission.go
@@ -7,6 +7,7 @@ import (
 
 // Permission represents a permission and the description for it
 type Permission struct {
+	Code        string `json:"code"`
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
 }

--- a/team.go
+++ b/team.go
@@ -10,11 +10,10 @@ import (
 
 // Team is a named group of users (has many members)
 type Team struct {
-	ID             string    `json:"id"`
-	Name           string    `json:"name,omitempty"`
-	OrganisationID string    `json:"organisation_id,omitempty"`
-	CreatedAt      time.Time `json:"created_at,omitempty"`
-	UpdatedAt      time.Time `json:"updated_at,omitempty"`
+	ID        string    `json:"id"`
+	Name      string    `json:"name,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
 }
 
 // TeamMember is a link record between User and Team.
@@ -43,9 +42,9 @@ func (c *Client) ListTeams() ([]Team, error) {
 	return teams, nil
 }
 
-// CreateTeam creates a new team in either the account or organisation depending on which field has a non-blank value
-func (c *Client) CreateTeam(name, organisationID, accountID string) (*Team, error) {
-	data := map[string]string{"name": name, "organisation_id": organisationID, "account_id": accountID}
+// CreateTeam creates a new team in the account
+func (c *Client) CreateTeam(name string) (*Team, error) {
+	data := map[string]string{"name": name}
 	resp, err := c.SendPostRequest("/v2/teams", data)
 	if err != nil {
 		return nil, decodeError(err)

--- a/team_test.go
+++ b/team_test.go
@@ -25,17 +25,14 @@ func TestListTeams(t *testing.T) {
 
 func TestCreateTeam(t *testing.T) {
 	client, server, _ := NewClientForTesting(map[string]string{
-		"/v2/teams": `{"id":"12345","name":"Org Admin"}`,
+		"/v2/teams": `{"name":"Org Admin"}`,
 	})
 	defer server.Close()
 
-	got, err := client.CreateTeam("Org Admin", "12345", "abcde")
+	got, err := client.CreateTeam("Org Admin")
 	if err != nil {
 		t.Errorf("Request returned an error: %s", err)
 		return
-	}
-	if got.ID != "12345" {
-		t.Errorf("Expected %s, got %s", "12345", got.ID)
 	}
 	if got.Name != "Org Admin" {
 		t.Errorf("Expected %s, got %s", "admin", got.Name)


### PR DESCRIPTION
This PR aims to add a function `FindTeam` which finds a team inside an organisation either by ID or by Name.