### PR TITLE
Add TransferTerabytes to size structure

### DIFF
--- a/instance_size.go
+++ b/instance_size.go
@@ -9,14 +9,15 @@ import (
 
 // InstanceSize represents an available size for instances to launch
 type InstanceSize struct {
-	ID            string `json:"id,omitempty"`
-	Name          string `json:"name,omitempty"`
-	NiceName      string `json:"nice_name,omitempty"`
-	CPUCores      int    `json:"cpu_cores,omitempty"`
-	RAMMegabytes  int    `json:"ram_mb,omitempty"`
-	DiskGigabytes int    `json:"disk_gb,omitempty"`
-	Description   string `json:"description,omitempty"`
-	Selectable    bool   `json:"selectable,omitempty"`
+	ID                string `json:"id,omitempty"`
+	Name              string `json:"name,omitempty"`
+	NiceName          string `json:"nice_name,omitempty"`
+	CPUCores          int    `json:"cpu_cores,omitempty"`
+	RAMMegabytes      int    `json:"ram_mb,omitempty"`
+	DiskGigabytes     int    `json:"disk_gb,omitempty"`
+	TransferTerabytes int    `json:"transfer_tb,omitempty"`
+	Description       string `json:"description,omitempty"`
+	Selectable        bool   `json:"selectable,omitempty"`
 }
 
 // ListInstanceSizes returns all availble sizes of instances


### PR DESCRIPTION
This is just to match a new interface coming in the API response (separate PR, will comment) so that transfer terabytes is available for James to display on the homepage. The new sizes.yml has been rolled out to production regions.