### PR TITLE
removed the k3s image filter

### DIFF
--- a/disk_image.go
+++ b/disk_image.go
@@ -31,14 +31,7 @@ func (c *Client) ListDiskImages() ([]DiskImage, error) {
 		return nil, err
 	}
 
-	filteredDiskImages := make([]DiskImage, 0)
-	for _, diskImage := range diskImages {
-		if !strings.Contains(diskImage.Name, "k3s") {
-			filteredDiskImages = append(filteredDiskImages, diskImage)
-		}
-	}
-
-	return filteredDiskImages, nil
+	return diskImages, nil
 }
 
 // GetDiskImage get one disk image using the id


### PR DESCRIPTION
Consuming the civogo library, I should see what I see in the rest API. Any "work" done in the client should only be when the developer requests it separately from the call to interact with the API. 