### PR TITLE
Add `Ports` field to FirewallRule

### DIFF
--- a/firewall.go
+++ b/firewall.go
@@ -51,7 +51,7 @@ type FirewallRuleConfig struct {
 	Action     string   `json:"action"`
 	Label      string   `json:"label,omitempty"`
 	// Ports will be chosen over StartPort,EndPort if both are provided
-	Ports string `json:"ports"`
+	Ports string `json:"ports,omitempty"`
 }
 
 // FirewallConfig is how you specify the details when creating a new firewall

--- a/firewall.go
+++ b/firewall.go
@@ -50,6 +50,8 @@ type FirewallRuleConfig struct {
 	Direction  string   `json:"direction"`
 	Action     string   `json:"action"`
 	Label      string   `json:"label,omitempty"`
+	// Ports will be chosen over StartPort,EndPort if both are provided
+	Ports string `json:"ports"`
 }
 
 // FirewallConfig is how you specify the details when creating a new firewall


### PR DESCRIPTION
### Description

This PR adds `Ports` field to `FirewallRuleConfig` similar to our API.