### PR TITLE
Add "FindRegion" and "GetDefaultRegion" methods

### DIFF
--- a/fake_client.go
+++ b/fake_client.go
@@ -976,7 +976,8 @@ func (c *FakeClient) FindRegion(search string) (*Region, error) {
 		}
 	}
 
-	return nil, nil
+	err = fmt.Errorf("unable to find region %s, zero matches", search)
+	return nil, ZeroMatchesError.wrap(err)
 }
 
 // GetDefaultRegion implemented in a fake way for automated tests
@@ -992,7 +993,8 @@ func (c *FakeClient) GetDefaultRegion() (*Region, error) {
 		}
 	}
 
-	return nil, nil
+	err = fmt.Errorf("unable to find default region, zero matches")
+	return nil, ZeroMatchesError.wrap(err)
 }
 
 // CreateSnapshot implemented in a fake way for automated tests

--- a/fake_client.go
+++ b/fake_client.go
@@ -123,6 +123,8 @@ type Clienter interface {
 
 	// Regions
 	ListRegions() ([]Region, error)
+	FindRegion(search string) (*Region, error)
+	GetDefaultRegion() (*Region, error)
 
 	// Snapshots
 	// CreateSnapshot(name string, r *SnapshotConfig) (*Snapshot, error)
@@ -959,6 +961,38 @@ func (c *FakeClient) ListRegions() ([]Region, error) {
 			Default: true,
 		},
 	}, nil
+}
+
+// FindRegion implemented in a fake way for automated tests
+func (c *FakeClient) FindRegion(search string) (*Region, error) {
+	regions, err := c.ListRegions()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, region := range regions {
+		if strings.Contains(region.Name, search) {
+			return &region, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// GetDefaultRegion implemented in a fake way for automated tests
+func (c *FakeClient) GetDefaultRegion() (*Region, error) {
+	regions, err := c.ListRegions()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, region := range regions {
+		if region.Default {
+			return &region, nil
+		}
+	}
+
+	return nil, nil
 }
 
 // CreateSnapshot implemented in a fake way for automated tests


### PR DESCRIPTION
This PR adds the following methods:

- `FindRegion(search string) (*Region, error)`
- `GetDefaultRegion() (*Region, error)`

to the `Clienter` interface. Also the implementation of these fake methods is done in the `FakeClient` type.