### PR TITLE
fix cluster type tag on json causing it not to be populated

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -166,7 +166,7 @@ type KubernetesVersion struct {
 	Version     string `json:"version"`
 	Type        string `json:"type"`
 	Default     bool   `json:"default,omitempty"`
-	ClusterType string `json:"cluster_type,omitempty"`
+	ClusterType string `json:"clusterType,omitempty"`
 }
 
 // ListKubernetesClusters returns all cluster of kubernetes in the account


### PR DESCRIPTION
This fix ensures that the `ClusterType` field in the `KubernetesVersion` struct is populated after calling `ListAvailableKubernetesVersions`

Fixing this problem: https://github.com/civo/civogo/issues/138