### PR TITLE
Add region field to create and update request for KfCluster

### DIFF
--- a/kfcluster.go
+++ b/kfcluster.go
@@ -24,12 +24,14 @@ type CreateKfClusterReq struct {
 	Name       string `json:"name" validate:"required"`
 	NetworkID  string `json:"network_id" validate:"required"`
 	FirewallID string `json:"firewall_id"`
-	Size       string `json:"size"` //what sizes?
+	Size       string `json:"size"`
+	Region     string `json:"region"`
 }
 
 // UpdateKfClusterReq is the request for updating a KfCluster.
 type UpdateKfClusterReq struct {
-	Name string `json:"name"`
+	Name   string `json:"name"`
+	Region string `json:"region"`
 	// Size string `json:"size"`
 }
 


### PR DESCRIPTION
## Description

This PR adds a new field `Region` to Create and Update requests for kfcluster. This is required when creating/updating a kfcluster from the CLI.