### PR TITLE
rename user_given_name to service_name for loadbalancer

### DIFF
--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -29,7 +29,7 @@ type LoadBalancerBackendConfig struct {
 type LoadBalancer struct {
 	ID                           string                `json:"id"`
 	Name                         string                `json:"name"`
-	UserGivenName                string                `json:"user_given_name,omitempty"`
+	ServiceName                  string                `json:"service_name,omitempty"`
 	Algorithm                    string                `json:"algorithm"`
 	Backends                     []LoadBalancerBackend `json:"backends"`
 	ExternalTrafficPolicy        string                `json:"external_traffic_policy,omitempty"`
@@ -52,7 +52,7 @@ type LoadBalancer struct {
 type LoadBalancerConfig struct {
 	Region                       string                      `json:"region"`
 	Name                         string                      `json:"name"`
-	UserGivenName                string                      `json:"user_given_name,omitempty"`
+	ServiceName                  string                      `json:"service_name,omitempty"`
 	NetworkID                    string                      `json:"network_id,omitempty"`
 	Algorithm                    string                      `json:"algorithm,omitempty"`
 	Backends                     []LoadBalancerBackendConfig `json:"backends"`
@@ -77,7 +77,7 @@ type LoadBalancerOptions struct {
 type LoadBalancerUpdateConfig struct {
 	Region                       string                      `json:"region"`
 	Name                         string                      `json:"name,omitempty"`
-	UserGivenName                string                      `json:"user_given_name,omitempty"`
+	ServiceName                  string                      `json:"service_name,omitempty"`
 	Algorithm                    string                      `json:"algorithm,omitempty"`
 	Backends                     []LoadBalancerBackendConfig `json:"backends,omitempty"`
 	ExternalTrafficPolicy        string                      `json:"external_traffic_policy,omitempty"`

--- a/loadbalancer_test.go
+++ b/loadbalancer_test.go
@@ -113,7 +113,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 		"/v2/loadbalancers": `{
 			"id": "56dca3ae-ea3f-480f-9b25-abf90b439729",
 			"name": "test-default-lb",
-			"user_given_name": "lb",
+			"service_name": "lb",
 			"network_id": "b064d568-5869-427c-827a-77d48cde6a2e",
 			"algorithm": "round_robin",
 			"backends": [
@@ -143,10 +143,10 @@ func TestCreateLoadBalancer(t *testing.T) {
 	}
 
 	expected := &LoadBalancer{
-		ID:            "56dca3ae-ea3f-480f-9b25-abf90b439729",
-		Name:          "test-default-lb",
-		UserGivenName: "lb",
-		Algorithm:     "round_robin",
+		ID:          "56dca3ae-ea3f-480f-9b25-abf90b439729",
+		Name:        "test-default-lb",
+		ServiceName: "lb",
+		Algorithm:   "round_robin",
 		Backends: []LoadBalancerBackend{
 			{
 				IP:         "192.168.1.3",
@@ -174,7 +174,7 @@ func TestUpdateLoadBalancer(t *testing.T) {
 		"/v2/loadbalancers/a1bd123c-b7e2-4d4f-9fda-7940c7e06b38": `{
 			"id": "a1bd123c-b7e2-4d4f-9fda-7940c7e06b38",
 			"name": "test-lb-updated",
-			"user_given_name": "updated",
+			"service_name": "updated",
 			"network_id": "b064d568-5869-427c-827a-77d48cde6a2e",
 			"algorithm": "round_robin",
 			"external_traffic_policy": "Cluster",
@@ -209,7 +209,7 @@ func TestUpdateLoadBalancer(t *testing.T) {
 	expected := &LoadBalancer{
 		ID:                    "a1bd123c-b7e2-4d4f-9fda-7940c7e06b38",
 		Name:                  "test-lb-updated",
-		UserGivenName:         "updated",
+		ServiceName:           "updated",
 		Algorithm:             "round_robin",
 		ExternalTrafficPolicy: "Cluster",
 		Backends: []LoadBalancerBackend{
@@ -239,7 +239,7 @@ func TestGetLoadBalancer(t *testing.T) {
 		"/v2/loadbalancers/a1bd123c-b7e2-4d4f-9fda-7940c7e06b38": `{
 			"id": "a1bd123c-b7e2-4d4f-9fda-7940c7e06b38",
 			"name": "test-lb-updated",
-			"user_given_name": "updated",
+			"service_name": "updated",
 			"network_id": "b064d568-5869-427c-827a-77d48cde6a2e",
 			"algorithm": "round_robin",
 			"external_traffic_policy": "Cluster",
@@ -271,7 +271,7 @@ func TestGetLoadBalancer(t *testing.T) {
 	expected := &LoadBalancer{
 		ID:                    "a1bd123c-b7e2-4d4f-9fda-7940c7e06b38",
 		Name:                  "test-lb-updated",
-		UserGivenName:         "updated",
+		ServiceName:           "updated",
 		Algorithm:             "round_robin",
 		ExternalTrafficPolicy: "Cluster",
 		Backends: []LoadBalancerBackend{


### PR DESCRIPTION
rename `user_given_name` to `service_name` for loadbalancer to be more understandable by users