### PR TITLE
Add firewall ID in Cluster Config

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -144,6 +144,7 @@ type KubernetesClusterConfig struct {
 	Applications      string                        `json:"applications,omitempty"`
 	InstanceFirewall  string                        `json:"instance_firewall,omitempty"`
 	FirewallRule      string                        `json:"firewall_rule,omitempty"`
+	FirewallID        string                        `json:"firewall_id,omitempty"`
 	CNIPlugin         string                        `json:"cni_plugin,omitempty"`
 }
 


### PR DESCRIPTION
## Description

Add `FirewallID` field in the Cluster config. This will help us in fixing https://github.com/civo/cli/issues/444