### PR TITLE
Send correct message from civogo sdk when api key is invalid

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -31,9 +31,11 @@ var (
 	VolumeInvalidSizeError                  = constError("VolumeInvalidSizeError")
 
 	DatabaseAccountDestroyError      = constError("DatabaseAccountDestroyError")
-	DatabaseAccountNotFoundError     = constError("DatabaseAccountNotFoundError")
 	DatabaseAccountAccessDeniedError = constError("DatabaseAccountAccessDeniedError")
 	DatabaseCreatingAccountError     = constError("DatabaseCreatingAccountError")
+
+	// Invalid API Key Error
+	InvalidAPIKeyError = constError("InvalidAPIKeyError")
 
 	DatabaseUpdatingAccountError = constError("DatabaseUpdatingAccountError")
 	DatabaseAccountStatsError    = constError("DatabaseAccountStatsError")
@@ -396,8 +398,9 @@ func decodeError(err error) error {
 			err := errors.New(msg.String())
 			return DatabaseAccountDestroyError.wrap(err)
 		case "database_account_not_found":
-			err := errors.New(msg.String())
-			return DatabaseAccountNotFoundError.wrap(err)
+			msg := "API Key is invalid, please visit https://dashboard.civo.com/security to generate a new one"
+			err := errors.New(msg)
+			return InvalidAPIKeyError.wrap(err)
 		case "database_account_access_denied":
 			err := errors.New(msg.String())
 			return DatabaseAccountAccessDeniedError.wrap(err)


### PR DESCRIPTION
[Issue link in cli repo](https://github.com/civo/cli/issues/312)

**Description** 
When Civo users attempt to use the CLI with an incorrect API key, the error message displayed in the terminal is both unclear and exposes internal details, which is not user-friendly. This PR addresses that issue by providing a more meaningful and helpful error message.

This is more of a workaround PR.
Currently, Civo CLI relies on the civogo SDK, which communicates with the Civo backend. When an invalid API key is used, the backend responds with an error message like:
```
{
    "code": "database_account_not_found",
    "reason": "Failed to find the account within the internal database"
}
```

This message is then passed along and presented to the user as: (on terminal)
```
Error: DatabaseAccountNotFoundError: Failed to find the account within the internal database
```

**Changes in this PR and suggestions** - 
The error message database_account_not_found will now be translated to a more user-friendly message:
InvalidAPIKeyError: "API Key is invalid, please visit https://dashboard.civo.com/security to generate a new one"` 

**Suggestions**:
While this specific message "database_account_not_found" for an invalid api key could have some historical context, it would be better if the backend error were more descriptive, such as using codes like `invalid_api_key` or `wrong_api_key` to reflect the actual issue. 
For now, this PR focuses on improving the user-facing message to provide clarity and guidance on resolving the issue.

Let me know in case you guys want to change the incoming message from the backend, I will refactor and accommodate for those changes in subsequent PRs.

For now, we should be in a good shape to unblock the issue .