### PR TITLE
Add fetch instance vnc details api in civigo library

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -392,8 +392,8 @@ func (c *Client) SetInstanceFirewall(id, firewallID string) (*SimpleResponse, er
 	return response, err
 }
 
-// GetInstanceVNCDetails gets the VNC details for an instance
-func (c *Client) GetInstanceVNCDetails(id string) (*InstanceVNCDetails, error) {
+// InitInstanceVNC gets the VNC details for an instance
+func (c *Client) InitInstanceVNC(id string) (*InstanceVNCDetails, error) {
 	resp, err := c.SendPutRequest(fmt.Sprintf("/v2/instances/%s/vnc", id), "")
 	if err != nil {
 		return nil, decodeError(err)

--- a/instance.go
+++ b/instance.go
@@ -104,6 +104,17 @@ type InstanceConfig struct {
 	AttachedVolume   []AttachedVolume `json:"attached_volume"`
 }
 
+// Instance VNC details
+type InstanceVNCDetails struct {
+	URI    string `json:"uri"`
+	Result string `json:"result"`
+	Name   string `json:"name"`
+	Label  string `json:"label"`
+	// Adding code and reason to the struct to handle the error response as well
+	Code   string `json:"code"`
+	Reason string `json:"reason"`
+}
+
 // ListInstances returns a page of Instances owned by the calling API account
 func (c *Client) ListInstances(page int, perPage int) (*PaginatedInstanceList, error) {
 	url := "/v2/instances"
@@ -379,4 +390,16 @@ func (c *Client) SetInstanceFirewall(id, firewallID string) (*SimpleResponse, er
 
 	response, err := c.DecodeSimpleResponse(resp)
 	return response, err
+}
+
+// GetInstanceVNCDetails gets the VNC details for an instance
+func (c *Client) GetInstanceVNCDetails(id string) (*InstanceVNCDetails, error) {
+	resp, err := c.SendPutRequest(fmt.Sprintf("/v2/instances/%s/vnc", id), "")
+	if err != nil {
+		return nil, decodeError(err)
+	}
+
+	instance := InstanceVNCDetails{}
+	err = json.NewDecoder(bytes.NewReader(resp)).Decode(&instance)
+	return &instance, err
 }

--- a/instance_test.go
+++ b/instance_test.go
@@ -437,7 +437,7 @@ func TestSetInstanceFirewall(t *testing.T) {
 	EnsureSuccessfulSimpleResponse(t, got, err)
 }
 
-func TestGetInstanceVNCDetailsSuccessful(t *testing.T) {
+func TestInitInstanceVNCSuccessful(t *testing.T) {
 	client, server, _ := NewAdvancedClientForTesting([]ConfigAdvanceClientForTesting{
 		{
 			Method: "PUT",
@@ -452,7 +452,7 @@ func TestGetInstanceVNCDetailsSuccessful(t *testing.T) {
 	})
 	defer server.Close()
 
-	got, _ := client.GetInstanceVNCDetails("12345")
+	got, _ := client.InitInstanceVNC("12345")
 
 	tests := []struct {
 		field, expected, actual string
@@ -470,7 +470,7 @@ func TestGetInstanceVNCDetailsSuccessful(t *testing.T) {
 	}
 }
 
-func TestGetInstanceVNCDetailsInvalid(t *testing.T) {
+func TestInitInstanceVNCInvalid(t *testing.T) {
 	client, server, _ := NewAdvancedClientForTesting([]ConfigAdvanceClientForTesting{
 		{
 			Method: "PUT",
@@ -485,7 +485,7 @@ func TestGetInstanceVNCDetailsInvalid(t *testing.T) {
 	})
 	defer server.Close()
 
-	got, _ := client.GetInstanceVNCDetails("invalidid")
+	got, _ := client.InitInstanceVNC("invalidid")
 
 	tests := []struct {
 		field, expected, actual string


### PR DESCRIPTION
[**Ticket link**](https://github.com/civo/civogo/issues/211)

**Description** - 
This PR aims to introduce an API for fetching the VNC details of an instance. This API will be used internally in the command: civo instance vnc INSTANCE-ID/NAME, which will be implemented in future PRs.

**Please note:**
This is the first part of a broader workflow. I have submitted this PR to gather incremental feedback as I continue to work on the next phase, which involves integrating the command into the CLI tool.
