### PR TITLE
Add DNSRecordTypeNS

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -67,6 +67,9 @@ const (
 
 	// DNSRecordTypeTXT represents an TXT record
 	DNSRecordTypeTXT = "TXT"
+
+	// DNSRecordTypeNS represents an NS record
+	DNSRecordTypeNS = "NS"
 )
 
 var (


### PR DESCRIPTION
This adds DNSRecordTypeNS. Civo API now supports the creation of NS records, so civogo should reflect this.

Closes #221.