### PR TITLE
Feat: Add gofmt formatting check support for Windows in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
-on: [push, pull_request]
 name: Test
+
+on: [push, pull_request]
+
 jobs:
   test:
     strategy:
@@ -8,14 +10,28 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Test
-      run: go test ./...
-    - name: Ensure correctly formatted
-      if: runner.os == 'Linux'
-      run: test -z "$(gofmt -l $(find . -type f -name '*.go'))"
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run tests
+        run: go test ./...
+
+      - name: Ensure correctly formatted on Linux
+        if: runner.os == 'Linux'
+        run: test -z "$(gofmt -l $(find . -type f -name '*.go'))"
+
+      - name: Ensure correctly formatted on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $files = gofmt -l .
+          if ($files) {
+            Write-Output "The following files need formatting:"
+            Write-Output $files
+            exit 1
+          } else {
+            Write-Output "All files are correctly formatted."
+          }


### PR DESCRIPTION
###  What This PR Adds

This PR enhances the GitHub Actions CI pipeline by **adding Windows support for gofmt formatting checks**, ensuring consistency across platforms.

### Summary of Changes

- ➕ Added a Windows-specific step to perform `gofmt -l` check using PowerShell
- 🔄 Preserved existing Linux formatting logic (no changes made to Ubuntu behavior)
- 🧪 Verified the formatting check fails for unformatted code and passes after `gofmt -w`

### 🖥️ Test Output (Local Verification on Windows) with sample unformatted code.
![scriptRunAfter](https://github.com/user-attachments/assets/0e21baed-3a6a-4248-851d-18eaaf3d5b53)


#### ❌ Before Formatting
![screnshotScriptRUNBefore](https://github.com/user-attachments/assets/0fbdda67-abae-4dfd-b31a-3589837c086f)


```powershell
main.go
The following files need formatting:
main.go
