### PR TITLE
[Fix] Snapshot Schedules Update: make paused field optional

### DIFF
--- a/snapshot_schedule.go
+++ b/snapshot_schedule.go
@@ -66,7 +66,7 @@ type CreateSnapshotInstance struct {
 type UpdateSnapshotScheduleRequest struct {
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
-	Paused      bool   `json:"paused,omitempty"`
+	Paused      *bool  `json:"paused,omitempty"`
 }
 
 // CreateSnapshotSchedule creates a new snapshot schedule


### PR DESCRIPTION
This MR makes the `Paused` field in `UpdateSnapshotScheduleRequest` nullable, since it's an optional parameter and its zero value `false` is not invalid.