### PR TITLE
fix: FindInstance fails when there's one exact match and multiple partial matches

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -164,27 +164,19 @@ func (c *Client) FindInstance(search string) (*Instance, error) {
 		return nil, decodeError(err)
 	}
 
-	exactMatch := false
 	partialMatchesCount := 0
 	result := Instance{}
 
 	for _, value := range instances {
 		if value.Hostname == search || value.ID == search {
-			exactMatch = true
-			result = value
-			break
+			return &value, nil
 		} else if strings.Contains(value.Hostname, search) || strings.Contains(value.ID, search) {
-			if !exactMatch {
-				result = value
-				partialMatchesCount++
-				if partialMatchesCount > 1 {
-					break
-				}
-			}
+			partialMatchesCount++
+			result = value
 		}
 	}
 
-	if exactMatch || partialMatchesCount == 1 {
+	if partialMatchesCount == 1 {
 		return &result, nil
 	} else if partialMatchesCount > 1 {
 		err := fmt.Errorf("unable to find %s because there were multiple matches", search)

--- a/instance_test.go
+++ b/instance_test.go
@@ -22,7 +22,30 @@ func TestListInstances(t *testing.T) {
 
 func TestFindInstance(t *testing.T) {
 	client, server, _ := NewClientForTesting(map[string]string{
-		"/v2/instances": `{"page": 1, "per_page": 20, "pages": 2, "items":[{"id": "12345", "hostname": "foo.example.com"}, {"id":"67890", "hostname": "bar.zip.com"}]}`,
+		"/v2/instances": `
+		{
+			"page": 1,
+			"per_page": 20,
+			"pages": 2,
+			"items": [
+				{
+					"id": "12345",
+					"hostname": "foo.example.com"
+				}, 
+				{
+					"id": "67890",
+					"hostname": "bar.zip.com"
+				},
+				{
+					"id": "98765",
+					"hostname": "baz.zip.com"
+				},
+				{
+					"id": "43210",
+					"hostname": "zip.com"
+				}
+			]
+		}`,
 	})
 	defer server.Close()
 
@@ -46,9 +69,19 @@ func TestFindInstance(t *testing.T) {
 		t.Errorf("Expected %s, got %s", "67890", got.ID)
 	}
 
+	got, _ = client.FindInstance("baz.zip.com")
+	if got.ID != "98765" {
+		t.Errorf("Expected %s, got %s", "98765", got.ID)
+	}
+
 	_, err := client.FindInstance("com")
 	if err.Error() != "MultipleMatchesError: unable to find com because there were multiple matches" {
 		t.Errorf("Expected %s, got %s", "unable to find com because there were multiple matches", err.Error())
+	}
+
+	got, _ = client.FindInstance("zip.com")
+	if got.ID != "43210" {
+		t.Errorf("Expected %s, got %s", "43210", got.ID)
 	}
 
 	_, err = client.FindInstance("missing")


### PR DESCRIPTION
The `Client.FindInstance` method currently fails finding exact matches when multiple partial matches are found before it.

Imagine the scenario where you have `[ "instance", "instance2", "instance3"]`. Attempting to find `"instance"` would succeed because it is the first one in the list.
Now consider `["instance2", "instance3", "instance"]`: the current implementation would exit the loop after finding two partial matches, returning an error.

This fixes it by never breaking the loop unless an exact match is found. When the loop terminates, we can check if we've found one or more partial matches and act accordingly.