### PR TITLE
Remove default size from instance specification

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	// DefaultInstanceUser is the default username used in newly created instances.
 	DefaultInstanceUser string = "civo"
 )
 


### PR DESCRIPTION
This MR removes a default size parameter to be specified here in CivoGo, preferring to use the API as the single source of truth for default sizes when not specified.