### PR TITLE
Auto-paginate the no-arg List* helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,21 @@
 
+Unreleased
+=============
+
+* **Behaviour change**: `ListIPs`, `ListAccounts`, `ListApplications`,
+  `ListDatabases`, `ListKubernetesClusters`, and `ListObjectStores` now
+  iterate server-side pagination internally and return every item the
+  account owns, not just the first 20. The merged response always reports
+  `Page=1, Pages=1, PerPage=len(Items)`. Callers iterating `Items` are
+  unaffected; callers inspecting `Page`/`Pages`/`PerPage` to drive their
+  own iteration should drop that logic.
+* `ListAllInstances` and `FindObjectStoreCredential` no longer use the
+  brittle `per_page=99999999` / `per_page=10000` workaround; both go
+  through the new shared iterator (`paginateAll` in `pagination.go`).
+* Hard cap: each `List*` call returns `ErrPaginationCapExceeded` rather
+  than spinning if the server reports more than 100 pages / 10,000 items.
+* Originating customer report: api-go epic civo&598 + civogo epic civo&599.
+
 0.2.57
 =============
 2021-11-02

--- a/account.go
+++ b/account.go
@@ -3,6 +3,7 @@ package civogo
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 )
 
 // PaginatedAccounts returns a paginated list of Account object
@@ -15,17 +16,21 @@ type PaginatedAccounts struct {
 
 // ListAccounts lists all accounts
 func (c *Client) ListAccounts() (*PaginatedAccounts, error) {
-	resp, err := c.SendGetRequest("/v2/accounts")
+	items, err := paginateAll("accounts", func(page, perPage int) ([]Account, int, error) {
+		resp, err := c.SendGetRequest(fmt.Sprintf("/v2/accounts?page=%d&per_page=%d", page, perPage))
+		if err != nil {
+			return nil, 0, decodeError(err)
+		}
+		pg := PaginatedAccounts{}
+		if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&pg); err != nil {
+			return nil, 0, decodeError(err)
+		}
+		return pg.Items, pg.Pages, nil
+	})
 	if err != nil {
-		return nil, decodeError(err)
+		return nil, err
 	}
-
-	accounts := &PaginatedAccounts{}
-	if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&accounts); err != nil {
-		return nil, decodeError(err)
-	}
-
-	return accounts, nil
+	return &PaginatedAccounts{Page: 1, Pages: 1, PerPage: len(items), Items: items}, nil
 }
 
 // GetAccountID returns the account ID

--- a/application.go
+++ b/application.go
@@ -75,17 +75,21 @@ var ErrAppDomainNotFound = fmt.Errorf("domain not found")
 
 // ListApplications returns all applications in that specific region
 func (c *Client) ListApplications() (*PaginatedApplications, error) {
-	resp, err := c.SendGetRequest("/v2/applications")
+	items, err := paginateAll("applications", func(page, perPage int) ([]Application, int, error) {
+		resp, err := c.SendGetRequest(fmt.Sprintf("/v2/applications?page=%d&per_page=%d", page, perPage))
+		if err != nil {
+			return nil, 0, decodeError(err)
+		}
+		pg := PaginatedApplications{}
+		if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&pg); err != nil {
+			return nil, 0, decodeError(err)
+		}
+		return pg.Items, pg.Pages, nil
+	})
 	if err != nil {
-		return nil, decodeError(err)
+		return nil, err
 	}
-
-	application := &PaginatedApplications{}
-	if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&application); err != nil {
-		return nil, decodeError(err)
-	}
-
-	return application, nil
+	return &PaginatedApplications{Page: 1, Pages: 1, PerPage: len(items), Items: items}, nil
 }
 
 // GetApplication returns an application by ID

--- a/application_test.go
+++ b/application_test.go
@@ -40,9 +40,11 @@ func TestListApplications(t *testing.T) {
 		return
 	}
 
+	// The SDK auto-paginates: the merged response always reports
+	// Page=1, Pages=1, PerPage=len(Items) — see paginateAll in pagination.go.
 	expected := &PaginatedApplications{
 		Page:    1,
-		PerPage: 20,
+		PerPage: 1,
 		Pages:   1,
 		Items: []Application{
 			{

--- a/database.go
+++ b/database.go
@@ -81,17 +81,21 @@ type RestoreDatabaseRequest struct {
 
 // ListDatabases returns a list of all databases
 func (c *Client) ListDatabases() (*PaginatedDatabases, error) {
-	resp, err := c.SendGetRequest("/v2/databases")
+	items, err := paginateAll("databases", func(page, perPage int) ([]Database, int, error) {
+		resp, err := c.SendGetRequest(fmt.Sprintf("/v2/databases?page=%d&per_page=%d", page, perPage))
+		if err != nil {
+			return nil, 0, decodeError(err)
+		}
+		pg := PaginatedDatabases{}
+		if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&pg); err != nil {
+			return nil, 0, err
+		}
+		return pg.Items, pg.Pages, nil
+	})
 	if err != nil {
-		return nil, decodeError(err)
-	}
-
-	databases := &PaginatedDatabases{}
-	if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&databases); err != nil {
 		return nil, err
 	}
-
-	return databases, nil
+	return &PaginatedDatabases{Page: 1, Pages: 1, PerPage: len(items), Items: items}, nil
 }
 
 // GetDatabase finds a database by the database UUID

--- a/database_test.go
+++ b/database_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestListDatabases(t *testing.T) {
 	client, server, _ := NewClientForTesting(map[string]string{
-		"/v2/databases": `{"page": 1, "per_page": 20, "pages": 2, "items":[{"id": "12345", "name": "test-db"}]}`,
+		"/v2/databases": `{"page": 1, "per_page": 20, "pages": 1, "items":[{"id": "12345", "name": "test-db"}]}`,
 	})
 	defer server.Close()
 
@@ -17,10 +17,12 @@ func TestListDatabases(t *testing.T) {
 		return
 	}
 
+	// The SDK auto-paginates: the merged response always reports
+	// Page=1, Pages=1, PerPage=len(Items) — see paginateAll in pagination.go.
 	expected := &PaginatedDatabases{
 		Page:    1,
-		PerPage: 20,
-		Pages:   2,
+		PerPage: 1,
+		Pages:   1,
 		Items: []Database{
 			{
 				ID:   "12345",

--- a/instance.go
+++ b/instance.go
@@ -152,14 +152,20 @@ func (c *Client) ListInstances(page int, perPage int) (*PaginatedInstanceList, e
 	return &PaginatedInstances, err
 }
 
-// ListAllInstances returns all (well, upto 99,999,999 instances) Instances owned by the calling API account
+// ListAllInstances returns every Instance owned by the calling API account
+// by iterating the paginated /v2/instances endpoint until exhausted.
 func (c *Client) ListAllInstances() ([]Instance, error) {
-	instances, err := c.ListInstances(1, 99999999)
+	items, err := paginateAll("instances", func(page, perPage int) ([]Instance, int, error) {
+		pg, err := c.ListInstances(page, perPage)
+		if err != nil {
+			return nil, 0, err
+		}
+		return pg.Items, pg.Pages, nil
+	})
 	if err != nil {
-		return []Instance{}, decodeError(err)
+		return []Instance{}, err
 	}
-
-	return instances.Items, nil
+	return items, nil
 }
 
 // FindInstance finds a instance by either part of the ID or part of the hostname

--- a/instance_test.go
+++ b/instance_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestListInstances(t *testing.T) {
 	client, server, _ := NewClientForTesting(map[string]string{
-		"/v2/instances": `{"page": 1, "per_page": 20, "pages": 2, "items":[{"id": "12345", "hostname": "foo.example.com"}]}`,
+		"/v2/instances": `{"page": 1, "per_page": 20, "pages": 1, "items":[{"id": "12345", "hostname": "foo.example.com"}]}`,
 	})
 	defer server.Close()
 
@@ -26,7 +26,7 @@ func TestFindInstance(t *testing.T) {
 		{
 			"page": 1,
 			"per_page": 20,
-			"pages": 2,
+			"pages": 1,
 			"items": [
 				{
 					"id": "12345",

--- a/ip.go
+++ b/ip.go
@@ -61,17 +61,21 @@ type Actions struct {
 
 // ListIPs returns all reserved IPs in that specific region
 func (c *Client) ListIPs() (*PaginatedIPs, error) {
-	resp, err := c.SendGetRequest("/v2/ips")
+	items, err := paginateAll("ips", func(page, perPage int) ([]IP, int, error) {
+		resp, err := c.SendGetRequest(fmt.Sprintf("/v2/ips?page=%d&per_page=%d", page, perPage))
+		if err != nil {
+			return nil, 0, decodeError(err)
+		}
+		pg := PaginatedIPs{}
+		if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&pg); err != nil {
+			return nil, 0, err
+		}
+		return pg.Items, pg.Pages, nil
+	})
 	if err != nil {
-		return nil, decodeError(err)
-	}
-
-	ips := &PaginatedIPs{}
-	if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&ips); err != nil {
 		return nil, err
 	}
-
-	return ips, nil
+	return &PaginatedIPs{Page: 1, Pages: 1, PerPage: len(items), Items: items}, nil
 }
 
 // GetIP finds an reserved IP by the full ID

--- a/ip_test.go
+++ b/ip_test.go
@@ -28,9 +28,11 @@ func TestListIPs(t *testing.T) {
 		return
 	}
 
+	// The SDK auto-paginates: the merged response always reports
+	// Page=1, Pages=1, PerPage=len(Items) — see paginateAll in pagination.go.
 	expected := &PaginatedIPs{
 		Page:    1,
-		PerPage: 20,
+		PerPage: 1,
 		Pages:   1,
 		Items: []IP{
 			{

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -200,17 +200,21 @@ type KubernetesVersion struct {
 
 // ListKubernetesClusters returns all cluster of kubernetes in the account
 func (c *Client) ListKubernetesClusters() (*PaginatedKubernetesClusters, error) {
-	resp, err := c.SendGetRequest("/v2/kubernetes/clusters")
+	items, err := paginateAll("kubernetes/clusters", func(page, perPage int) ([]KubernetesCluster, int, error) {
+		resp, err := c.SendGetRequest(fmt.Sprintf("/v2/kubernetes/clusters?page=%d&per_page=%d", page, perPage))
+		if err != nil {
+			return nil, 0, decodeError(err)
+		}
+		pg := PaginatedKubernetesClusters{}
+		if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&pg); err != nil {
+			return nil, 0, err
+		}
+		return pg.Items, pg.Pages, nil
+	})
 	if err != nil {
-		return nil, decodeError(err)
-	}
-
-	kubernetes := &PaginatedKubernetesClusters{}
-	if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&kubernetes); err != nil {
 		return nil, err
 	}
-
-	return kubernetes, nil
+	return &PaginatedKubernetesClusters{Page: 1, Pages: 1, PerPage: len(items), Items: items}, nil
 }
 
 // FindKubernetesCluster finds a Kubernetes cluster by either part of the ID or part of the name

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -72,9 +72,11 @@ func TestListKubernetesClusters(t *testing.T) {
 	createAtInstance, _ := time.Parse(time.RFC3339, "2019-09-23T13:03:00.000+01:00")
 	updateAt, _ := time.Parse(time.RFC3339, "2019-09-23T13:02:59.000+01:00")
 
+	// The SDK auto-paginates: the merged response always reports
+	// Page=1, Pages=1, PerPage=len(Items) — see paginateAll in pagination.go.
 	expected := &PaginatedKubernetesClusters{
 		Page:    1,
-		PerPage: 20,
+		PerPage: 1,
 		Pages:   1,
 		Items: []KubernetesCluster{
 			{

--- a/objectstore.go
+++ b/objectstore.go
@@ -57,17 +57,21 @@ type UpdateObjectStoreRequest struct {
 
 // ListObjectStores returns all objectstores in that specific region
 func (c *Client) ListObjectStores() (*PaginatedObjectstores, error) {
-	resp, err := c.SendGetRequest("/v2/objectstores")
+	items, err := paginateAll("objectstores", func(page, perPage int) ([]ObjectStore, int, error) {
+		resp, err := c.SendGetRequest(fmt.Sprintf("/v2/objectstores?page=%d&per_page=%d", page, perPage))
+		if err != nil {
+			return nil, 0, decodeError(err)
+		}
+		pg := PaginatedObjectstores{}
+		if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&pg); err != nil {
+			return nil, 0, err
+		}
+		return pg.Items, pg.Pages, nil
+	})
 	if err != nil {
-		return nil, decodeError(err)
-	}
-
-	stores := &PaginatedObjectstores{}
-	if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&stores); err != nil {
 		return nil, err
 	}
-
-	return stores, nil
+	return &PaginatedObjectstores{Page: 1, Pages: 1, PerPage: len(items), Items: items}, nil
 }
 
 // GetObjectStore finds an objectstore by the full ID

--- a/objectstore_credential.go
+++ b/objectstore_credential.go
@@ -78,18 +78,26 @@ func (c *Client) GetObjectStoreCredential(id string) (*ObjectStoreCredential, er
 	return &oscr, nil
 }
 
-// FindObjectStoreCredential finds an objectstore credential by name or by accesskeyID
+// FindObjectStoreCredential finds an objectstore credential by name or by accesskeyID.
+// All pages of the credential list are iterated so the search covers every
+// credential the account owns, not just the first page.
 func (c *Client) FindObjectStoreCredential(search string) (*ObjectStoreCredential, error) {
-	creds, err := c.ListObjectStoreCredentials(1, 10000)
+	items, err := paginateAll("objectstore/credentials", func(page, perPage int) ([]ObjectStoreCredential, int, error) {
+		pg, err := c.ListObjectStoreCredentials(page, perPage)
+		if err != nil {
+			return nil, 0, err
+		}
+		return pg.Items, pg.Pages, nil
+	})
 	if err != nil {
-		return nil, decodeError(err)
+		return nil, err
 	}
 
 	exactMatch := false
 	partialMatchesCount := 0
 	result := ObjectStoreCredential{}
 
-	for _, value := range creds.Items {
+	for _, value := range items {
 		if value.AccessKeyID == search || value.Name == search || value.ID == search {
 			exactMatch = true
 			result = value

--- a/objectstore_test.go
+++ b/objectstore_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestListObjectStores(t *testing.T) {
 	client, server, _ := NewClientForTesting(map[string]string{
-		"/v2/objectstores": `{"page": 1, "per_page": 20, "pages": 2, "items":[{"id": "12345", "name": "test-objectstore"}]}`,
+		"/v2/objectstores": `{"page": 1, "per_page": 20, "pages": 1, "items":[{"id": "12345", "name": "test-objectstore"}]}`,
 	})
 	defer server.Close()
 
@@ -17,10 +17,12 @@ func TestListObjectStores(t *testing.T) {
 		return
 	}
 
+	// The SDK auto-paginates: the merged response always reports
+	// Page=1, Pages=1, PerPage=len(Items) — see paginateAll in pagination.go.
 	expected := &PaginatedObjectstores{
 		Page:    1,
-		PerPage: 20,
-		Pages:   2,
+		PerPage: 1,
+		Pages:   1,
 		Items: []ObjectStore{
 			{
 				ID:   "12345",

--- a/pagination.go
+++ b/pagination.go
@@ -1,0 +1,78 @@
+package civogo
+
+import "fmt"
+
+// Internal pagination defaults and safety caps used by the no-arg List*
+// convenience functions. These exist so callers writing
+// `c.ListIPs()` do not silently get a truncated result when the account
+// owns more than the server-side default per_page.
+//
+// Values picked deliberately:
+//   - paginationPerPage:  large enough that most accounts complete in one
+//     round trip, small enough that the server is not asked to marshal a
+//     huge response. 100 matches the upper bound used by api-go's existing
+//     ReadPaginationOptions defaults in practice.
+//   - paginationMaxPages: bounded so a runaway loop on a misbehaving server
+//     cannot spin forever. With per_page=100 this caps a List call at
+//     10,000 items.
+//
+// If the bound is reached, paginateAll returns an explicit error rather
+// than silently truncating again — the whole point of this package.
+const (
+	paginationPerPage  = 100
+	paginationMaxPages = 100
+	paginationMaxItems = paginationPerPage * paginationMaxPages
+)
+
+// ErrPaginationCapExceeded is returned by paginateAll when the iteration
+// would exceed paginationMaxPages or paginationMaxItems. Callers seeing
+// this should switch to an explicit-page API (e.g. ListInstances) and
+// process results in chunks.
+type ErrPaginationCapExceeded struct {
+	Resource   string
+	PagesSeen  int
+	ItemsSeen  int
+	TotalPages int
+}
+
+func (e ErrPaginationCapExceeded) Error() string {
+	return fmt.Sprintf(
+		"civogo: pagination cap exceeded for %s (saw %d pages / %d items; server reports %d total pages; max %d pages / %d items)",
+		e.Resource, e.PagesSeen, e.ItemsSeen, e.TotalPages, paginationMaxPages, paginationMaxItems,
+	)
+}
+
+// pageFetcher fetches a single page of a paginated v2 list endpoint.
+// It must return the items on that page, the server's reported total
+// number of pages, and any error.
+type pageFetcher[T any] func(page, perPage int) (items []T, totalPages int, err error)
+
+// paginateAll iterates a paginated v2 list endpoint sequentially,
+// starting at page 1, until all pages reported by the server have been
+// consumed. It returns the merged Items slice in server order.
+//
+// Iteration is sequential (never parallel) because the server's total
+// page count is not known until page 1 returns. A hard cap on pages and
+// items guards against runaway responses.
+func paginateAll[T any](resource string, fetch pageFetcher[T]) ([]T, error) {
+	var all []T
+	page := 1
+	for {
+		items, totalPages, err := fetch(page, paginationPerPage)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, items...)
+		if len(all) > paginationMaxItems {
+			return nil, ErrPaginationCapExceeded{Resource: resource, PagesSeen: page, ItemsSeen: len(all), TotalPages: totalPages}
+		}
+		if totalPages <= page {
+			break
+		}
+		if page >= paginationMaxPages {
+			return nil, ErrPaginationCapExceeded{Resource: resource, PagesSeen: page, ItemsSeen: len(all), TotalPages: totalPages}
+		}
+		page++
+	}
+	return all, nil
+}

--- a/pagination_test.go
+++ b/pagination_test.go
@@ -1,0 +1,163 @@
+package civogo
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// newMultiPageServer returns an httptest.Server that responds to GET requests
+// on path. The server reads the `page` query parameter and returns a
+// PaginatedX-shaped JSON body whose Items slice contains itemsPerPage entries
+// for every page up to totalPages, except the final page which gets the
+// remainder. The body's `pages` field always reports totalPages so the SDK
+// knows when to stop.
+//
+// itemBuilder is called with the global item index (0-based) and must return
+// a JSON object snippet that fits inside the Items array.
+func newMultiPageServer(t *testing.T, path string, totalItems, itemsPerPage int, itemBuilder func(idx int) string) (*Client, *httptest.Server) {
+	t.Helper()
+	totalPages := totalItems / itemsPerPage
+	if totalItems%itemsPerPage > 0 {
+		totalPages++
+	}
+	if totalItems == 0 {
+		totalPages = 1
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if !strings.HasPrefix(req.URL.Path, path) {
+			http.NotFound(rw, req)
+			return
+		}
+		page, _ := strconv.Atoi(req.URL.Query().Get("page"))
+		if page == 0 {
+			page = 1
+		}
+		start := (page - 1) * itemsPerPage
+		end := start + itemsPerPage
+		if end > totalItems {
+			end = totalItems
+		}
+		items := make([]string, 0, end-start)
+		for i := start; i < end; i++ {
+			items = append(items, itemBuilder(i))
+		}
+		body := fmt.Sprintf(
+			`{"page":%d,"per_page":%d,"pages":%d,"items":[%s]}`,
+			page, itemsPerPage, totalPages, strings.Join(items, ","),
+		)
+		rw.Write([]byte(body))
+	}))
+
+	client, err := NewClientForTestingWithServer(server)
+	if err != nil {
+		server.Close()
+		t.Fatalf("NewClientForTestingWithServer: %v", err)
+	}
+	return client, server
+}
+
+// TestPaginateAll_SinglePage verifies the early-exit path: server reports one
+// page so iteration must not request page 2.
+func TestPaginateAll_SinglePage(t *testing.T) {
+	requests := 0
+	client, server := newMultiPageServer(t, "/v2/ips", 5, 100, func(i int) string {
+		requests++
+		return fmt.Sprintf(`{"id":"ip-%d"}`, i)
+	})
+	defer server.Close()
+
+	got, err := client.ListIPs()
+	if err != nil {
+		t.Fatalf("ListIPs: %v", err)
+	}
+	if len(got.Items) != 5 {
+		t.Fatalf("expected 5 items, got %d", len(got.Items))
+	}
+	if got.Page != 1 || got.Pages != 1 || got.PerPage != 5 {
+		t.Errorf("expected merged Page=1 Pages=1 PerPage=5, got Page=%d Pages=%d PerPage=%d", got.Page, got.Pages, got.PerPage)
+	}
+}
+
+// TestPaginateAll_MultiPage exercises the customer's failure case: more items
+// than fit on a single page (perPage+1 trailing item on page 2). The original
+// bug (no iteration in civogo) dropped the trailing items entirely; this
+// regression test asserts every item is now returned.
+func TestPaginateAll_MultiPage(t *testing.T) {
+	const total = 250 // > paginationPerPage (100), forces 3 pages
+	client, server := newMultiPageServer(t, "/v2/ips", total, paginationPerPage, func(i int) string {
+		return fmt.Sprintf(`{"id":"ip-%d"}`, i)
+	})
+	defer server.Close()
+
+	got, err := client.ListIPs()
+	if err != nil {
+		t.Fatalf("ListIPs: %v", err)
+	}
+	if len(got.Items) != total {
+		t.Fatalf("expected %d items, got %d", total, len(got.Items))
+	}
+	// Order across pages must be preserved.
+	for i, item := range got.Items {
+		want := fmt.Sprintf("ip-%d", i)
+		if item.ID != want {
+			t.Errorf("items[%d].ID = %q, want %q", i, item.ID, want)
+		}
+	}
+	if got.Page != 1 || got.Pages != 1 || got.PerPage != total {
+		t.Errorf("expected merged Page=1 Pages=1 PerPage=%d, got Page=%d Pages=%d PerPage=%d", total, got.Page, got.Pages, got.PerPage)
+	}
+}
+
+// TestPaginateAll_TrailingItem covers the exact shape of the customer ticket
+// that motivated this fix: items count = perPage + 1, so page 2 contains a
+// single trailing entry that the old (no-iteration) SDK silently dropped.
+func TestPaginateAll_TrailingItem(t *testing.T) {
+	const total = paginationPerPage + 1
+	client, server := newMultiPageServer(t, "/v2/ips", total, paginationPerPage, func(i int) string {
+		return fmt.Sprintf(`{"id":"ip-%d"}`, i)
+	})
+	defer server.Close()
+
+	got, err := client.ListIPs()
+	if err != nil {
+		t.Fatalf("ListIPs: %v", err)
+	}
+	if len(got.Items) != total {
+		t.Fatalf("expected %d items, got %d", total, len(got.Items))
+	}
+	if got.Items[total-1].ID != fmt.Sprintf("ip-%d", total-1) {
+		t.Errorf("expected trailing item ID ip-%d, got %q", total-1, got.Items[total-1].ID)
+	}
+}
+
+// TestPaginateAll_CapExceeded asserts the hard cap returns an explicit error
+// rather than spinning. We forge a server that always reports a huge page
+// count so the loop must terminate via the cap.
+func TestPaginateAll_CapExceeded(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Write([]byte(`{"page":1,"per_page":100,"pages":999999,"items":[{"id":"ip-x"}]}`))
+	}))
+	defer server.Close()
+	client, err := NewClientForTestingWithServer(server)
+	if err != nil {
+		t.Fatalf("NewClientForTestingWithServer: %v", err)
+	}
+
+	_, err = client.ListIPs()
+	if err == nil {
+		t.Fatal("expected pagination cap error, got nil")
+	}
+	var capErr ErrPaginationCapExceeded
+	if !errors.As(err, &capErr) {
+		t.Fatalf("expected ErrPaginationCapExceeded, got %T: %v", err, err)
+	}
+	if capErr.Resource != "ips" {
+		t.Errorf("expected Resource=ips, got %q", capErr.Resource)
+	}
+}


### PR DESCRIPTION
ListIPs, ListAccounts, ListApplications, ListDatabases, ListKubernetesClusters and ListObjectStores previously sent a single GET /v2/... with no pagination parameters and silently returned whatever fit on the server-side first page (default 20 items). For accounts with more resources than that — typical in production — page 2 onward was invisible to civogo callers including civo-cli (`civo ip ls`) and terraform-provider-civo (`civo_reserved_ip`, `civo_kubernetes_cluster`, `civo_object_store`, `civo_database`).

The customer ticket that surfaced this: an account with > 20 Reserved IPs in fra1 / lon1 could not see one specific IP via the CLI or Terraform. Tracked in api-go epic civo&598 (server-side off-by-one, fixed in civo/api-go!1354) and civogo epic civo&599 (this change).

The fix introduces a shared `paginateAll` helper in `pagination.go` and routes the six no-arg `List*` functions through it. The merged response always reports `Page=1, Pages=1, PerPage=len(Items)`. Iteration is sequential and capped (100 pages / 10,000 items) with an explicit ErrPaginationCapExceeded rather than spinning forever.

Two existing magic-number workarounds were retired in the same change:
- ListAllInstances no longer uses ListInstances(1, 99999999).
- FindObjectStoreCredential no longer uses ListObjectStoreCredentials(1, 10000).

Both depended on api-go's paginator early-return path and would silently re-truncate the day server-side adds a per_page cap. They now share the same iterator.

Includes regression tests covering: single page, multi-page in order, trailing-item-on-last-page (the customer's case), and hard-cap exhaustion. Updated affected fixtures that asserted the old buggy semantics (Pages>1 on a single-item response, PerPage=20 on the merged result).