### PR TITLE
fix: bump Go to 1.25.10 to clear stdlib vulnerabilities

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v6
       with:
-        go-version: ${{ vars.GO_VERSION || '1.24.13' }}
+        go-version: ${{ vars.GO_VERSION || '1.25.10' }}
         cache: true
 
     - name: Run golangci-lint

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,5 +14,5 @@ jobs:
     - name: Run govulncheck
       uses: golang/govulncheck-action@v1
       with:
-        go-version-input: ${{ vars.GO_VERSION || '1.24.13' }}
+        go-version-input: ${{ vars.GO_VERSION || '1.25.10' }}
         go-package: ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v6
       with:
-        go-version: ${{ vars.GO_VERSION || '1.24.13' }}
+        go-version: ${{ vars.GO_VERSION || '1.25.10' }}
         cache: true
 
     - name: Verify dependencies

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/civo/civogo
 
-go 1.24.13
+go 1.25.10
 
 require (
 	github.com/google/go-querystring v1.1.0


### PR DESCRIPTION
govulncheck on master currently reports 7 stdlib vulnerabilities affecting this codebase via existing call paths in client.go and utils/random.go:

  GO-2026-4971  net          (fixed go1.25.10)
  GO-2026-4947  crypto/x509  (fixed go1.25.9)
  GO-2026-4946  crypto/x509  (fixed go1.25.9)
  GO-2026-4918  net/http     (fixed go1.25.10)
  GO-2026-4870  crypto/tls   (fixed go1.25.9)
  GO-2026-4602  os           (fixed go1.25.8)
  GO-2026-4601  net/url      (fixed go1.25.8)

These were published after the last push to master (2026-03-03), so master's cached security badge is stale; any new PR currently re-scans and fails. 1.24.x is no longer receiving patches for these — the most recent 1.24 release on go.dev/dl remains 1.24.13. Moving to the latest patched 1.25.x line.

Verified locally with go1.25.10:
- go build ./...                 clean
- go test -race ./...            pass
- go mod tidy                    no changes
- govulncheck ./...              "Your code is affected by 0 vulnerabilities"

Bumps both the go.mod `go` directive and all three workflow fallback versions, matching the pattern of !723f618 (the previous 1.24.12 → 1.24.13 bump). Maintainers can also update the repo-level `vars.GO_VERSION` if that is set; the workflow fallback only matters when the variable is unset.