### PR TITLE
Fix/listvpcips pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ Unreleased
   is the path the terraform-provider-civo `civo_reserved_ip` data source
   migrated to, so customers hitting the v0.7.1 SDK via terraform still
   saw Reserved IPs past page 1 silently dropped until this follow-up.
+* **Same audit**: `ListDatabaseBackup` (and therefore `FindDatabaseBackup`)
+  now iterate internally. Previously sent no pagination params to the
+  `/v2/databases/{id}/backups` endpoint, so any database with > 20 backups
+  silently truncated — affecting `civo db backup list` and
+  `civo db backup delete <name>` in civo-cli.
+* New `ListAllActions(filters *ActionListRequest) ([]Action, error)`
+  function pairs with `ListActions` the way `ListAllInstances` pairs with
+  `ListInstances`. Iterates server-side pagination internally; ignores
+  any `Page`/`PerPage` set on the filters. Use this when enumerating all
+  actions; keep `ListActions` when you genuinely want a single page.
 
 0.2.57
 =============

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Unreleased
 * Hard cap: each `List*` call returns `ErrPaginationCapExceeded` rather
   than spinning if the server reports more than 100 pages / 10,000 items.
 * Originating customer report: api-go epic civo&598 + civogo epic civo&599.
+* **Follow-up**: `ListVPCIPs` (and therefore `FindVPCIP`) now also iterate
+  internally. Missed in the v0.7.1 cut — the VPC API uses a different
+  endpoint (`/v2/vpc/ips`) and was not covered by the initial audit. This
+  is the path the terraform-provider-civo `civo_reserved_ip` data source
+  migrated to, so customers hitting the v0.7.1 SDK via terraform still
+  saw Reserved IPs past page 1 silently dropped until this follow-up.
 
 0.2.57
 =============

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,4 @@
 
-Unreleased
-=============
-
-* **Behaviour change**: `ListIPs`, `ListAccounts`, `ListApplications`,
-  `ListDatabases`, `ListKubernetesClusters`, and `ListObjectStores` now
-  iterate server-side pagination internally and return every item the
-  account owns, not just the first 20. The merged response always reports
-  `Page=1, Pages=1, PerPage=len(Items)`. Callers iterating `Items` are
-  unaffected; callers inspecting `Page`/`Pages`/`PerPage` to drive their
-  own iteration should drop that logic.
-* `ListAllInstances` and `FindObjectStoreCredential` no longer use the
-  brittle `per_page=99999999` / `per_page=10000` workaround; both go
-  through the new shared iterator (`paginateAll` in `pagination.go`).
-* Hard cap: each `List*` call returns `ErrPaginationCapExceeded` rather
-  than spinning if the server reports more than 100 pages / 10,000 items.
-* Originating customer report: api-go epic civo&598 + civogo epic civo&599.
-* **Follow-up**: `ListVPCIPs` (and therefore `FindVPCIP`) now also iterate
-  internally. Missed in the v0.7.1 cut — the VPC API uses a different
-  endpoint (`/v2/vpc/ips`) and was not covered by the initial audit. This
-  is the path the terraform-provider-civo `civo_reserved_ip` data source
-  migrated to, so customers hitting the v0.7.1 SDK via terraform still
-  saw Reserved IPs past page 1 silently dropped until this follow-up.
-* **Same audit**: `ListDatabaseBackup` (and therefore `FindDatabaseBackup`)
-  now iterate internally. Previously sent no pagination params to the
-  `/v2/databases/{id}/backups` endpoint, so any database with > 20 backups
-  silently truncated — affecting `civo db backup list` and
-  `civo db backup delete <name>` in civo-cli.
-* New `ListAllActions(filters *ActionListRequest) ([]Action, error)`
-  function pairs with `ListActions` the way `ListAllInstances` pairs with
-  `ListInstances`. Iterates server-side pagination internally; ignores
-  any `Page`/`PerPage` set on the filters. Use this when enumerating all
-  actions; keep `ListActions` when you genuinely want a single page.
-
 0.2.57
 =============
 2021-11-02

--- a/action.go
+++ b/action.go
@@ -46,7 +46,10 @@ type ActionListRequest struct {
 	UserID       string `json:"user_id,omitempty" url:"user_id,omitempty"`
 }
 
-// ListActions returns a page of actions
+// ListActions returns a page of actions. Callers that want to enumerate
+// every action matching the supplied filters should use ListAllActions
+// instead — without explicit Page/PerPage values this function returns
+// only the server-side first page (default 20 items).
 func (c *Client) ListActions(listRequest *ActionListRequest) (*PaginateActionList, error) {
 	url := "/v2/actions"
 
@@ -63,4 +66,36 @@ func (c *Client) ListActions(listRequest *ActionListRequest) (*PaginateActionLis
 	paginateActionList := PaginateActionList{}
 	err = json.NewDecoder(bytes.NewReader(resp)).Decode(&paginateActionList)
 	return &paginateActionList, err
+}
+
+// ListAllActions returns every action matching the supplied filters by
+// iterating server-side pagination internally. Any Page/PerPage values
+// set on filters are ignored (the SDK chooses these to maximise iteration
+// safety; see paginateAll in pagination.go).
+//
+// Pass nil for filters to enumerate all actions on the account with no
+// filter criteria.
+func (c *Client) ListAllActions(filters *ActionListRequest) ([]Action, error) {
+	return paginateAll("actions", func(page, perPage int) ([]Action, int, error) {
+		req := ActionListRequest{}
+		if filters != nil {
+			req = *filters
+		}
+		req.Page = page
+		req.PerPage = perPage
+
+		vals, err := query.Values(&req)
+		if err != nil {
+			return nil, 0, err
+		}
+		resp, err := c.SendGetRequest(fmt.Sprintf("/v2/actions?%s", vals.Encode()))
+		if err != nil {
+			return nil, 0, decodeError(err)
+		}
+		pg := PaginateActionList{}
+		if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&pg); err != nil {
+			return nil, 0, err
+		}
+		return pg.Items, pg.Pages, nil
+	})
 }

--- a/action_test.go
+++ b/action_test.go
@@ -1,6 +1,10 @@
 package civogo
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -37,5 +41,111 @@ func TestListActionsWithFilter(t *testing.T) {
 	}
 	if len(allActions.Items) != 1 {
 		t.Errorf("Expected %d, got %d", 1, len(allActions.Items))
+	}
+}
+
+// TestListAllActions verifies the basic API contract of the new
+// auto-iterating wrapper: with a server that reports a single page, the
+// returned []Action contains every item.
+func TestListAllActions(t *testing.T) {
+	client, server, _ := NewClientForTesting(map[string]string{
+		"/v2/actions": `{"page":1,"per_page":100,"pages":1,"items":[{"id":1,"type":"instance-create","related_type":"instance"},{"id":2,"type":"instance-delete","related_type":"instance"}]}`,
+	})
+	defer server.Close()
+
+	got, err := client.ListAllActions(nil)
+	if err != nil {
+		t.Errorf("Request returned an error: %s", err)
+		return
+	}
+	if len(got) != 2 {
+		t.Errorf("Expected 2 actions, got %d", len(got))
+	}
+	if got[0].ID != 1 || got[1].ID != 2 {
+		t.Errorf("Expected actions with IDs [1, 2], got [%d, %d]", got[0].ID, got[1].ID)
+	}
+}
+
+// TestListAllActions_AcrossPages verifies that ListAllActions iterates a
+// multi-page response and returns every item in order. Uses the multi-page
+// mock server helper from pagination_test.go (same package).
+func TestListAllActions_AcrossPages(t *testing.T) {
+	const total = paginationPerPage*2 + 7 // 3 pages
+	client, server := newMultiPageServer(t, "/v2/actions", total, paginationPerPage, func(i int) string {
+		return fmt.Sprintf(`{"id":%d,"type":"instance-create","related_type":"instance"}`, i)
+	})
+	defer server.Close()
+
+	got, err := client.ListAllActions(nil)
+	if err != nil {
+		t.Errorf("Request returned an error: %s", err)
+		return
+	}
+	if len(got) != total {
+		t.Errorf("Expected %d actions, got %d", total, len(got))
+	}
+	for i, action := range got {
+		if action.ID != i {
+			t.Errorf("Expected action[%d].ID == %d, got %d", i, i, action.ID)
+		}
+	}
+}
+
+// TestListAllActions_PreservesFilters verifies that filter fields on the
+// caller-supplied ActionListRequest are forwarded to every page request,
+// while any Page/PerPage values on the filters are overridden by the
+// iterator (so a caller can't accidentally short-circuit pagination by
+// passing a small per_page).
+func TestListAllActions_PreservesFilters(t *testing.T) {
+	const total = paginationPerPage + 3 // 2 pages
+	var seenResourceType, seenPerPage string
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if rt := req.URL.Query().Get("resource_type"); rt != "" {
+			seenResourceType = rt
+		}
+		if pp := req.URL.Query().Get("per_page"); pp != "" {
+			seenPerPage = pp
+		}
+		page := req.URL.Query().Get("page")
+		if page == "" {
+			page = "1"
+		}
+		start := 0
+		if page == "2" {
+			start = paginationPerPage
+		}
+		var items []string
+		for i := start; i < start+paginationPerPage && i < total; i++ {
+			items = append(items, fmt.Sprintf(`{"id":%d,"type":"instance-create"}`, i))
+		}
+		fmt.Fprintf(rw, `{"page":%s,"per_page":%d,"pages":2,"items":[%s]}`,
+			page, paginationPerPage, strings.Join(items, ","))
+	}))
+	defer server.Close()
+	client, err := NewClientForTestingWithServer(server)
+	if err != nil {
+		t.Fatalf("NewClientForTestingWithServer: %v", err)
+	}
+
+	// Caller passes a filter AND bogus Page/PerPage values. Filter should
+	// be forwarded; iterator should override Page/PerPage.
+	filters := &ActionListRequest{
+		ResourceType: "instance",
+		Page:         999,
+		PerPage:      1,
+	}
+	got, err := client.ListAllActions(filters)
+	if err != nil {
+		t.Fatalf("ListAllActions: %v", err)
+	}
+	if len(got) != total {
+		t.Errorf("Expected %d actions, got %d", total, len(got))
+	}
+	if seenResourceType != "instance" {
+		t.Errorf("Expected resource_type=instance to be forwarded, got %q", seenResourceType)
+	}
+	if seenPerPage != fmt.Sprintf("%d", paginationPerPage) {
+		t.Errorf("Expected per_page=%d (iterator override), got %q", paginationPerPage, seenPerPage)
 	}
 }

--- a/database_backup.go
+++ b/database_backup.go
@@ -51,19 +51,27 @@ type DatabaseBackupUpdateRequest struct {
 	Region string `json:"region"`
 }
 
-// ListDatabaseBackup lists backups for database
+// ListDatabaseBackup lists backups for database.
+//
+// The SDK iterates server-side pagination internally so the returned
+// PaginatedDatabaseBackup always contains every backup for the database.
+// The merged response has Page=1, Pages=1, PerPage=len(Items).
 func (c *Client) ListDatabaseBackup(did string) (*PaginatedDatabaseBackup, error) {
-	resp, err := c.SendGetRequest(fmt.Sprintf("/v2/databases/%s/backups", did))
+	items, err := paginateAll("databases/"+did+"/backups", func(page, perPage int) ([]DatabaseBackup, int, error) {
+		resp, err := c.SendGetRequest(fmt.Sprintf("/v2/databases/%s/backups?page=%d&per_page=%d", did, page, perPage))
+		if err != nil {
+			return nil, 0, decodeError(err)
+		}
+		pg := PaginatedDatabaseBackup{}
+		if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&pg); err != nil {
+			return nil, 0, decodeError(err)
+		}
+		return pg.Items, pg.Pages, nil
+	})
 	if err != nil {
-		return nil, decodeError(err)
+		return nil, err
 	}
-
-	back := &PaginatedDatabaseBackup{}
-	if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&back); err != nil {
-		return nil, decodeError(err)
-	}
-
-	return back, nil
+	return &PaginatedDatabaseBackup{Page: 1, Pages: 1, PerPage: len(items), Items: items}, nil
 }
 
 // UpdateDatabaseBackup update database backup

--- a/pagination_test.go
+++ b/pagination_test.go
@@ -161,3 +161,51 @@ func TestPaginateAll_CapExceeded(t *testing.T) {
 		t.Errorf("expected Resource=ips, got %q", capErr.Resource)
 	}
 }
+
+// TestListVPCIPs_TrailingItem mirrors TestPaginateAll_TrailingItem but
+// against the VPC /v2/vpc/ips endpoint used by FindVPCIP — the path the
+// terraform-provider-civo civo_reserved_ip data source migrated to.
+// Without iteration, the alphabetically-last item on the last page was
+// silently dropped.
+func TestListVPCIPs_TrailingItem(t *testing.T) {
+	const total = paginationPerPage + 1
+	client, server := newMultiPageServer(t, "/v2/vpc/ips", total, paginationPerPage, func(i int) string {
+		return fmt.Sprintf(`{"id":"vpc-ip-%d"}`, i)
+	})
+	defer server.Close()
+
+	got, err := client.ListVPCIPs()
+	if err != nil {
+		t.Fatalf("ListVPCIPs: %v", err)
+	}
+	if len(got.Items) != total {
+		t.Fatalf("expected %d items, got %d", total, len(got.Items))
+	}
+	if got.Items[total-1].ID != fmt.Sprintf("vpc-ip-%d", total-1) {
+		t.Errorf("expected trailing item ID vpc-ip-%d, got %q", total-1, got.Items[total-1].ID)
+	}
+	if got.Page != 1 || got.Pages != 1 || got.PerPage != total {
+		t.Errorf("expected merged Page=1 Pages=1 PerPage=%d, got Page=%d Pages=%d PerPage=%d", total, got.Page, got.Pages, got.PerPage)
+	}
+}
+
+// TestFindVPCIP_FindsItemPastFirstPage covers the customer-visible
+// terraform-provider-civo symptom: data "civo_reserved_ip" with an id
+// whose owning IP sits past the first server page must resolve cleanly.
+func TestFindVPCIP_FindsItemPastFirstPage(t *testing.T) {
+	const total = paginationPerPage + 1
+	const target = paginationPerPage // 0-indexed; last item, exclusively on page 2
+	client, server := newMultiPageServer(t, "/v2/vpc/ips", total, paginationPerPage, func(i int) string {
+		return fmt.Sprintf(`{"id":"vpc-ip-%d","name":"name-%d"}`, i, i)
+	})
+	defer server.Close()
+
+	want := fmt.Sprintf("vpc-ip-%d", target)
+	got, err := client.FindVPCIP(want)
+	if err != nil {
+		t.Fatalf("FindVPCIP(%q): %v", want, err)
+	}
+	if got.ID != want {
+		t.Errorf("FindVPCIP returned ID=%q, want %q", got.ID, want)
+	}
+}

--- a/pagination_test.go
+++ b/pagination_test.go
@@ -209,3 +209,58 @@ func TestFindVPCIP_FindsItemPastFirstPage(t *testing.T) {
 		t.Errorf("FindVPCIP returned ID=%q, want %q", got.ID, want)
 	}
 }
+
+// TestListDatabaseBackup_TrailingItem covers ListDatabaseBackup against the
+// /v2/databases/{id}/backups endpoint. The endpoint paginates server-side
+// unconditionally and the SDK previously sent no per_page param, so any
+// database with > 20 backups silently truncated.
+func TestListDatabaseBackup_TrailingItem(t *testing.T) {
+	const total = paginationPerPage + 1
+	const dbID = "db-1234"
+	client, server := newMultiPageServer(t,
+		fmt.Sprintf("/v2/databases/%s/backups", dbID),
+		total, paginationPerPage,
+		func(i int) string {
+			return fmt.Sprintf(`{"id":"bk-%d"}`, i)
+		})
+	defer server.Close()
+
+	got, err := client.ListDatabaseBackup(dbID)
+	if err != nil {
+		t.Fatalf("ListDatabaseBackup: %v", err)
+	}
+	if len(got.Items) != total {
+		t.Fatalf("expected %d items, got %d", total, len(got.Items))
+	}
+	if got.Items[total-1].ID != fmt.Sprintf("bk-%d", total-1) {
+		t.Errorf("expected trailing item ID bk-%d, got %q", total-1, got.Items[total-1].ID)
+	}
+	if got.Page != 1 || got.Pages != 1 || got.PerPage != total {
+		t.Errorf("expected merged Page=1 Pages=1 PerPage=%d, got Page=%d Pages=%d PerPage=%d", total, got.Page, got.Pages, got.PerPage)
+	}
+}
+
+// TestListAllActions_MultiPage covers the new auto-iterating wrapper.
+// Filters supplied by the caller are preserved across page fetches;
+// any Page/PerPage in the filters is overridden by the iterator.
+func TestListAllActions_MultiPage(t *testing.T) {
+	const total = paginationPerPage*2 + 3 // forces 3 pages
+	client, server := newMultiPageServer(t, "/v2/actions", total, paginationPerPage, func(i int) string {
+		return fmt.Sprintf(`{"id":%d,"resource_type":"instance"}`, i)
+	})
+	defer server.Close()
+
+	// Caller passes filters with bogus Page/PerPage — iterator must override.
+	filters := &ActionListRequest{
+		ResourceType: "instance",
+		Page:         999,
+		PerPage:      999,
+	}
+	got, err := client.ListAllActions(filters)
+	if err != nil {
+		t.Fatalf("ListAllActions: %v", err)
+	}
+	if len(got) != total {
+		t.Fatalf("expected %d items, got %d", total, len(got))
+	}
+}

--- a/pagination_test.go
+++ b/pagination_test.go
@@ -162,58 +162,14 @@ func TestPaginateAll_CapExceeded(t *testing.T) {
 	}
 }
 
-// TestListVPCIPs_TrailingItem mirrors TestPaginateAll_TrailingItem but
-// against the VPC /v2/vpc/ips endpoint used by FindVPCIP — the path the
-// terraform-provider-civo civo_reserved_ip data source migrated to.
-// Without iteration, the alphabetically-last item on the last page was
-// silently dropped.
-func TestListVPCIPs_TrailingItem(t *testing.T) {
-	const total = paginationPerPage + 1
-	client, server := newMultiPageServer(t, "/v2/vpc/ips", total, paginationPerPage, func(i int) string {
-		return fmt.Sprintf(`{"id":"vpc-ip-%d"}`, i)
-	})
-	defer server.Close()
-
-	got, err := client.ListVPCIPs()
-	if err != nil {
-		t.Fatalf("ListVPCIPs: %v", err)
-	}
-	if len(got.Items) != total {
-		t.Fatalf("expected %d items, got %d", total, len(got.Items))
-	}
-	if got.Items[total-1].ID != fmt.Sprintf("vpc-ip-%d", total-1) {
-		t.Errorf("expected trailing item ID vpc-ip-%d, got %q", total-1, got.Items[total-1].ID)
-	}
-	if got.Page != 1 || got.Pages != 1 || got.PerPage != total {
-		t.Errorf("expected merged Page=1 Pages=1 PerPage=%d, got Page=%d Pages=%d PerPage=%d", total, got.Page, got.Pages, got.PerPage)
-	}
-}
-
-// TestFindVPCIP_FindsItemPastFirstPage covers the customer-visible
-// terraform-provider-civo symptom: data "civo_reserved_ip" with an id
-// whose owning IP sits past the first server page must resolve cleanly.
-func TestFindVPCIP_FindsItemPastFirstPage(t *testing.T) {
-	const total = paginationPerPage + 1
-	const target = paginationPerPage // 0-indexed; last item, exclusively on page 2
-	client, server := newMultiPageServer(t, "/v2/vpc/ips", total, paginationPerPage, func(i int) string {
-		return fmt.Sprintf(`{"id":"vpc-ip-%d","name":"name-%d"}`, i, i)
-	})
-	defer server.Close()
-
-	want := fmt.Sprintf("vpc-ip-%d", target)
-	got, err := client.FindVPCIP(want)
-	if err != nil {
-		t.Fatalf("FindVPCIP(%q): %v", want, err)
-	}
-	if got.ID != want {
-		t.Errorf("FindVPCIP returned ID=%q, want %q", got.ID, want)
-	}
-}
-
 // TestListDatabaseBackup_TrailingItem covers ListDatabaseBackup against the
 // /v2/databases/{id}/backups endpoint. The endpoint paginates server-side
 // unconditionally and the SDK previously sent no per_page param, so any
 // database with > 20 backups silently truncated.
+//
+// (Per-file regression tests for ListVPCIPs / FindVPCIP live in vpc_test.go;
+// ListAllActions has them in action_test.go. This package has no
+// database_backup_test.go file, so the regression sits here.)
 func TestListDatabaseBackup_TrailingItem(t *testing.T) {
 	const total = paginationPerPage + 1
 	const dbID = "db-1234"
@@ -237,30 +193,5 @@ func TestListDatabaseBackup_TrailingItem(t *testing.T) {
 	}
 	if got.Page != 1 || got.Pages != 1 || got.PerPage != total {
 		t.Errorf("expected merged Page=1 Pages=1 PerPage=%d, got Page=%d Pages=%d PerPage=%d", total, got.Page, got.Pages, got.PerPage)
-	}
-}
-
-// TestListAllActions_MultiPage covers the new auto-iterating wrapper.
-// Filters supplied by the caller are preserved across page fetches;
-// any Page/PerPage in the filters is overridden by the iterator.
-func TestListAllActions_MultiPage(t *testing.T) {
-	const total = paginationPerPage*2 + 3 // forces 3 pages
-	client, server := newMultiPageServer(t, "/v2/actions", total, paginationPerPage, func(i int) string {
-		return fmt.Sprintf(`{"id":%d,"resource_type":"instance"}`, i)
-	})
-	defer server.Close()
-
-	// Caller passes filters with bogus Page/PerPage — iterator must override.
-	filters := &ActionListRequest{
-		ResourceType: "instance",
-		Page:         999,
-		PerPage:      999,
-	}
-	got, err := client.ListAllActions(filters)
-	if err != nil {
-		t.Fatalf("ListAllActions: %v", err)
-	}
-	if len(got) != total {
-		t.Fatalf("expected %d items, got %d", total, len(got))
 	}
 }

--- a/vpc.go
+++ b/vpc.go
@@ -567,19 +567,27 @@ func (c *Client) DeleteVPCLoadBalancer(id string) (*SimpleResponse, error) {
 // VPC Reserved IPs - /v2/vpc/ips
 // =============================================================================
 
-// ListVPCIPs returns all reserved IPs in that specific region using VPC API path
+// ListVPCIPs returns all reserved IPs in that specific region using VPC API path.
+//
+// The SDK iterates server-side pagination internally so the returned
+// PaginatedIPs always contains every IP the account owns in the region.
+// The merged response has Page=1, Pages=1, PerPage=len(Items).
 func (c *Client) ListVPCIPs() (*PaginatedIPs, error) {
-	resp, err := c.SendGetRequest("/v2/vpc/ips")
+	items, err := paginateAll("vpc/ips", func(page, perPage int) ([]IP, int, error) {
+		resp, err := c.SendGetRequest(fmt.Sprintf("/v2/vpc/ips?page=%d&per_page=%d", page, perPage))
+		if err != nil {
+			return nil, 0, decodeError(err)
+		}
+		pg := PaginatedIPs{}
+		if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&pg); err != nil {
+			return nil, 0, err
+		}
+		return pg.Items, pg.Pages, nil
+	})
 	if err != nil {
-		return nil, decodeError(err)
-	}
-
-	ips := &PaginatedIPs{}
-	if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&ips); err != nil {
 		return nil, err
 	}
-
-	return ips, nil
+	return &PaginatedIPs{Page: 1, Pages: 1, PerPage: len(items), Items: items}, nil
 }
 
 // GetVPCIP finds a reserved IP by the full ID using VPC API path

--- a/vpc_test.go
+++ b/vpc_test.go
@@ -1,6 +1,7 @@
 package civogo
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -921,5 +922,59 @@ func TestDeleteVPCIP(t *testing.T) {
 	expected := &SimpleResponse{Result: "success"}
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("Expected %+v, got %+v", expected, got)
+	}
+}
+
+// TestListVPCIPs_IteratesAllPages verifies that ListVPCIPs auto-paginates
+// across the /v2/vpc/ips endpoint when the account owns more than the
+// server-side default per_page. Prior to this fix, the SDK sent a single
+// request without pagination params and silently truncated.
+//
+// Uses the multi-page mock server from pagination_test.go (same package),
+// which serves itemsPerPage entries on each page up to totalItems.
+func TestListVPCIPs_IteratesAllPages(t *testing.T) {
+	const total = paginationPerPage + 5 // forces a 2nd page
+	client, server := newMultiPageServer(t, "/v2/vpc/ips", total, paginationPerPage, func(i int) string {
+		return fmt.Sprintf(`{"id":"ip-%d","name":"ip-%d","ip":"10.0.0.%d"}`, i, i, i)
+	})
+	defer server.Close()
+
+	got, err := client.ListVPCIPs()
+	if err != nil {
+		t.Errorf("Request returned an error: %s", err)
+		return
+	}
+
+	if len(got.Items) != total {
+		t.Errorf("Expected %d items across all pages, got %d", total, len(got.Items))
+	}
+
+	// Verify the alphabetically-last item (the one historically dropped by
+	// the api-go off-by-one before deployment) is present.
+	wantLastID := fmt.Sprintf("ip-%d", total-1)
+	if got.Items[total-1].ID != wantLastID {
+		t.Errorf("Expected last item ID %s, got %s", wantLastID, got.Items[total-1].ID)
+	}
+}
+
+// TestFindVPCIP_OnSecondPage exercises the customer-visible terraform-provider
+// path: data "civo_reserved_ip" with an ID that sits past page 1 of /v2/vpc/ips.
+// Before this fix FindVPCIP returned a ZeroMatchesError for any such ID.
+func TestFindVPCIP_OnSecondPage(t *testing.T) {
+	const total = paginationPerPage + 1
+	const targetIdx = paginationPerPage // exclusively on page 2 (0-indexed)
+	client, server := newMultiPageServer(t, "/v2/vpc/ips", total, paginationPerPage, func(i int) string {
+		return fmt.Sprintf(`{"id":"ip-%d","name":"ip-%d","ip":"10.0.0.%d"}`, i, i, i)
+	})
+	defer server.Close()
+
+	wantID := fmt.Sprintf("ip-%d", targetIdx)
+	got, err := client.FindVPCIP(wantID)
+	if err != nil {
+		t.Errorf("Expected to find %s on page 2, got error: %s", wantID, err)
+		return
+	}
+	if got.ID != wantID {
+		t.Errorf("Expected ID %s, got %s", wantID, got.ID)
 	}
 }


### PR DESCRIPTION
  ## What changes

  **`ListVPCIPs`** (`vpc.go`) — caller-transparent; routes through `paginateAll` with the same merged-response shape (`Page=1, Pages=1, PerPage=len(Items)`) as the #285 fixes. `FindVPCIP` benefits transparently.

  **`ListDatabaseBackup`** (`database_backup.go`) — same caller-transparent fix. `FindDatabaseBackup` benefits transparently.

  **`ListActions`** (`action.go`) — left unchanged to preserve explicit pagination for any external Go consumer. Added a sibling **`ListAllActions(filters *ActionListRequest) ([]Action, error)`** that pairs with `ListActions` the way `ListAllInstances` pairs with `ListInstances`. Filters on the request are preserved across page fetches; any `Page`/`PerPage` set on filters is overridden by the iterator.

  **CHANGELOG.md** — removed the entries this PR (and #285) would have added. The repo's CHANGELOG hasn't been updated by other PRs since 2021; release notes live in git tags + GitHub Releases. Keeping the cleanup atomic with the fix release.

  ## Behaviour change

  Strictly additive. Callers receive items they were previously missing; no item that was previously returned disappears. The merged response shape matches #285's pattern.