### PR TITLE
Fix FindObjectStoreCredential for names longer than 30 characters

### DIFF
--- a/objectstore_credential.go
+++ b/objectstore_credential.go
@@ -97,11 +97,19 @@ func (c *Client) FindObjectStoreCredential(search string) (*ObjectStoreCredentia
 	partialMatchesCount := 0
 	result := ObjectStoreCredential{}
 
+	// The API generates credential names by trimming name prefixes longer
+	// than 30 characters down to 29 before appending a hash/uid suffix, so
+	// also try the trimmed prefix when matching long names.
+	trimmedSearch := search
+	if len(search) > 30 {
+		trimmedSearch = search[:29]
+	}
+
 	for _, value := range items {
 		if value.AccessKeyID == search || value.Name == search || value.ID == search {
 			exactMatch = true
 			result = value
-		} else if strings.Contains(value.AccessKeyID, search) || strings.Contains(value.Name, search) || strings.Contains(value.ID, search) {
+		} else if strings.Contains(value.AccessKeyID, search) || strings.Contains(value.Name, search) || strings.Contains(value.ID, search) || strings.Contains(value.Name, trimmedSearch) {
 			if !exactMatch {
 				result = value
 				partialMatchesCount++

--- a/objectstore_credential_test.go
+++ b/objectstore_credential_test.go
@@ -55,6 +55,36 @@ func TestFindObjectStoreCredential(t *testing.T) {
 	}
 }
 
+func TestFindObjectStoreCredentialLongName(t *testing.T) {
+	// Credentials auto-created alongside an object store whose name exceeds
+	// 30 characters get a generated name: the first 29 characters of the
+	// object store name plus a hash/uid suffix. Searching by the original
+	// full-length name must still find them.
+	client, server, _ := NewClientForTesting(map[string]string{
+		"/v2/objectstore/credentials": `{
+			"page": 1,
+			"per_page": 20,
+			"pages": 1,
+			"items": [
+			  {
+				"id": "12345",
+				"name": "k1-project-prod-project-bp-st-d6ca-160390"
+			  }
+			]
+		  }`,
+	})
+	defer server.Close()
+
+	got, err := client.FindObjectStoreCredential("k1-project-prod-project-bp-ste2")
+	if err != nil {
+		t.Errorf("Request returned an error: %s", err)
+		return
+	}
+	if got.ID != "12345" {
+		t.Errorf("Expected %s, got %s", "12345", got.ID)
+	}
+}
+
 func TestNewObjectStoreCredential(t *testing.T) {
 	client, server, _ := NewClientForTesting(map[string]string{
 		"/v2/objectstore/credentials": `{


### PR DESCRIPTION
## Problem

When an object store is created with a name longer than 30 characters (e.g. `k1-project-prod-project-bp-ste2`), the API generates the credential's name from the first 29 characters of the store name plus a hash/uid suffix (e.g. `k1-project-prod-project-bp-st-d6ca-160390`).

`FindObjectStoreCredential` searches with the original full-length name, which:
- fails the exact match, and
- fails the partial match, because `strings.Contains(storedName, search)` can never be true — the trim drops the tail of the search string, so it's no longer a substring of the stored name.

Result: `ZeroMatchesError` for a credential that exists. Names ≤ 30 characters are unaffected since the untrimmed name remains a prefix of the generated name.

## Fix

Mirror the API's trim rule in the partial-match check: when the search term is longer than 30 characters, additionally try its first 29 characters. This is an additive check, so exact matches, short names, and access-key/ID searches behave exactly as before, and the multiple-matches error still triggers on ambiguous prefixes.

## Testing

Added `TestFindObjectStoreCredentialLongName` covering the >30-character scenario. `go test ./...` and `go vet ./...` pass.