### PR TITLE
fix: validate IP entries in UpdateInstanceAllowedIPs

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -472,6 +473,15 @@ func (c *Client) GetRecoveryStatus(id string) (*SimpleResponse, error) {
 
 // UpdateInstanceAllowedIPs sets the list of IP addresses that an instance is allowed to use
 func (c *Client) UpdateInstanceAllowedIPs(id string, allowedIPs []string) (*SimpleResponse, error) {
+	// Validate entries up front so invalid addresses fail locally instead of
+	// surfacing as an opaque API error later.
+	for _, ip := range allowedIPs {
+		if net.ParseIP(ip) == nil {
+			if _, _, err := net.ParseCIDR(ip); err != nil {
+				return nil, fmt.Errorf("invalid IP address: %s", ip)
+			}
+		}
+	}
 	// Create a map to match the expected JSON structure
 	payload := map[string][]string{
 		"allowed_ips": allowedIPs,

--- a/instance_test.go
+++ b/instance_test.go
@@ -1,6 +1,7 @@
 package civogo
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -540,6 +541,41 @@ func TestUpdateInstanceAllowedIPs(t *testing.T) {
 	defer server.Close()
 
 	got, err := client.UpdateInstanceAllowedIPs("12345", []string{"192.168.1.10", "192.168.1.11"})
+	EnsureSuccessfulSimpleResponse(t, got, err)
+}
+
+func TestUpdateInstanceAllowedIPsRejectsInvalidIP(t *testing.T) {
+	client, server, _ := NewAdvancedClientForTesting([]ConfigAdvanceClientForTesting{})
+	defer server.Close()
+
+	got, err := client.UpdateInstanceAllowedIPs("12345", []string{"192.168.1.10", "not-an-ip"})
+	if err == nil {
+		t.Fatalf("expected error for invalid IP, got none")
+	}
+	if !strings.Contains(err.Error(), "not-an-ip") {
+		t.Fatalf("error should name the invalid entry, got: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil response on validation failure, got %v", got)
+	}
+}
+
+func TestUpdateInstanceAllowedIPsAcceptsCIDR(t *testing.T) {
+	client, server, _ := NewAdvancedClientForTesting([]ConfigAdvanceClientForTesting{
+		{
+			Method: "PUT",
+			Value: []ValueAdvanceClientForTesting{
+				{
+					RequestBody:  `"{"allowed_ips": ["10.0.0.0/24"]"`,
+					URL:          "/v2/instances/12345/allowed_ips",
+					ResponseBody: `{"result": "success"}`,
+				},
+			},
+		},
+	})
+	defer server.Close()
+
+	got, err := client.UpdateInstanceAllowedIPs("12345", []string{"10.0.0.0/24"})
 	EnsureSuccessfulSimpleResponse(t, got, err)
 }
 


### PR DESCRIPTION
Fixes #277

`UpdateInstanceAllowedIPs` forwarded its entries straight to the API, so a typo'd address came back as an opaque server-side error after a round trip. Entries are now validated locally with `net.ParseIP` (with `net.ParseCIDR` fallback so CIDR ranges remain accepted), returning `invalid IP address: <entry>` before any request is made.

## Validation

- `go build ./...` clean
- `go test -run TestUpdateInstanceAllowedIPs .` — 3 tests pass:
  - existing happy-path test (unchanged)
  - `TestUpdateInstanceAllowedIPsRejectsInvalidIP` — fails before the fix (request was sent, no local error), passes after
  - `TestUpdateInstanceAllowedIPsAcceptsCIDR` — CIDR entries keep working